### PR TITLE
Adjust module name to be canonical

### DIFF
--- a/fly/go.mod
+++ b/fly/go.mod
@@ -1,4 +1,4 @@
-module fly
+module github.com/wormhole-foundation/wormhole-explorer/fly
 
 go 1.19
 

--- a/fly/main.go
+++ b/fly/main.go
@@ -3,11 +3,12 @@ package main
 import (
 	"context"
 
-	"fly/guardiansets"
-	"fly/migration"
-	"fly/storage"
 	"fmt"
 	"os"
+
+	"github.com/wormhole-foundation/wormhole-explorer/fly/guardiansets"
+	"github.com/wormhole-foundation/wormhole-explorer/fly/migration"
+	"github.com/wormhole-foundation/wormhole-explorer/fly/storage"
 
 	"github.com/certusone/wormhole/node/pkg/common"
 	"github.com/certusone/wormhole/node/pkg/p2p"


### PR DESCRIPTION
Having the module be canonical enables other modules to import it.