### PR TITLE
[API] Add route `GET /swagger.json`

### DIFF
--- a/api/docs/controllers.go
+++ b/api/docs/controllers.go
@@ -1,0 +1,45 @@
+package docs
+
+import (
+	_ "embed"
+	"fmt"
+
+	"github.com/gofiber/fiber/v2"
+	"go.uber.org/zap"
+)
+
+type Controller struct {
+	logger *zap.Logger
+}
+
+func NewController(logger *zap.Logger) *Controller {
+
+	l := logger.With(zap.String("module", "DocsController"))
+
+	return &Controller{logger: l}
+}
+
+//go:embed swagger.json
+var swagger []byte
+
+// GetSwagger godoc
+// @Description Returns the swagger specification for this API.
+// @Tags Wormscan
+// @ID swagger
+// @Success 200 {object} object
+// @Failure 400
+// @Failure 500
+// @Router /swagger.json [get]
+func (c *Controller) GetSwagger(ctx *fiber.Ctx) error {
+
+	written, err := ctx.
+		Response().
+		BodyWriter().
+		Write(swagger)
+
+	if written != len(swagger) {
+		return fmt.Errorf("partial write to response body: wrote %d bytes, expected %d", written, len(swagger))
+	}
+
+	return err
+}

--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -1154,6 +1154,29 @@ const docTemplate = `{
                 }
             }
         },
+        "/swagger.json": {
+            "get": {
+                "description": "Returns the swagger specification for this API.",
+                "tags": [
+                    "Wormscan"
+                ],
+                "operationId": "swagger",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            }
+        },
         "/v1/governor/available_notional_by_chain": {
             "get": {
                 "description": "Get available notional by chainID\nSince from the wormhole-explorer point of view it is not a node, but has the information of all nodes,\nin order to build the endpoints it was assumed:\nThere are N number of remainingAvailableNotional values in the GovernorConfig collection. N = number of guardians\nfor a chainID. The smallest remainingAvailableNotional value for a chainID is used for the endpoint response.",

--- a/api/docs/swagger.json
+++ b/api/docs/swagger.json
@@ -1146,6 +1146,29 @@
                 }
             }
         },
+        "/swagger.json": {
+            "get": {
+                "description": "Returns the swagger specification for this API.",
+                "tags": [
+                    "Wormscan"
+                ],
+                "operationId": "swagger",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            }
+        },
         "/v1/governor/available_notional_by_chain": {
             "get": {
                 "description": "Get available notional by chainID\nSince from the wormhole-explorer point of view it is not a node, but has the information of all nodes,\nin order to build the endpoints it was assumed:\nThere are N number of remainingAvailableNotional values in the GovernorConfig collection. N = number of guardians\nfor a chainID. The smallest remainingAvailableNotional value for a chainID is used for the endpoint response.",

--- a/api/docs/swagger.yaml
+++ b/api/docs/swagger.yaml
@@ -1297,6 +1297,21 @@ paths:
           description: Internal Server Error
       tags:
       - Wormscan
+  /swagger.json:
+    get:
+      description: Returns the swagger specification for this API.
+      operationId: swagger
+      responses:
+        "200":
+          description: OK
+          schema:
+            type: object
+        "400":
+          description: Bad Request
+        "500":
+          description: Internal Server Error
+      tags:
+      - Wormscan
   /v1/governor/available_notional_by_chain:
     get:
       description: |-

--- a/api/main.go
+++ b/api/main.go
@@ -18,10 +18,11 @@ import (
 	"github.com/improbable-eng/grpc-web/go/grpcweb"
 
 	ipfslog "github.com/ipfs/go-log/v2"
+	"github.com/wormhole-foundation/wormhole-explorer/api/docs"
 	"github.com/wormhole-foundation/wormhole-explorer/api/handlers/governor"
 	"github.com/wormhole-foundation/wormhole-explorer/api/handlers/guardian"
 	"github.com/wormhole-foundation/wormhole-explorer/api/handlers/heartbeats"
-	"github.com/wormhole-foundation/wormhole-explorer/api/handlers/infrastructure"
+	infraestructure "github.com/wormhole-foundation/wormhole-explorer/api/handlers/infrastructure"
 	"github.com/wormhole-foundation/wormhole-explorer/api/handlers/observations"
 	"github.com/wormhole-foundation/wormhole-explorer/api/handlers/vaa"
 	wormscanCache "github.com/wormhole-foundation/wormhole-explorer/api/internal/cache"
@@ -105,6 +106,7 @@ func main() {
 	heartbeatsService := heartbeats.NewService(heartbeatsRepo, rootLogger)
 
 	// Setup controllers
+	docsCtrl := docs.NewController(rootLogger)
 	vaaCtrl := vaa.NewController(vaaService, rootLogger)
 	observationsCtrl := observations.NewController(obsService, rootLogger)
 	governorCtrl := governor.NewController(governorService, rootLogger)
@@ -125,6 +127,8 @@ func main() {
 	app.Use(logger.New(logger.Config{
 		Format: "level=info timestamp=${time} method=${method} path=${path} status${status} request_id=${locals:requestid}\n",
 	}))
+
+	app.Get("/swagger.json", docsCtrl.GetSwagger)
 
 	api := app.Group("/api/v1")
 	api.Use(cors.New()) // TODO CORS restrictions?


### PR DESCRIPTION
Expose the API's swagger spec under the route `GET /swagger.json`