### PR TITLE
Build API swagger on github workflows

### DIFF
--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -40,4 +40,4 @@ jobs:
 
     - name: Build API swagger
       working-directory: ./api
-      run: make doc
+      run: go install github.com/swaggo/swag/cmd/swag@latest && make doc

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -37,3 +37,7 @@ jobs:
     - name: Test parser
       working-directory: ./parser
       run: make test
+
+    - name: Build API swagger
+      working-directory: ./api
+      run: make doc


### PR DESCRIPTION
This will help prevent the API swagger docs from breaking