### PR TITLE
[API] Remove duplicated model for VAAs

### DIFF
--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -961,7 +961,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/response.Response-array_vaa_VaaWithPayload"
+                            "$ref": "#/definitions/response.Response-array_vaa_VaaDoc"
                         }
                     },
                     "400": {
@@ -1165,7 +1165,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/response.Response-array_vaa_VaaWithPayload"
+                            "$ref": "#/definitions/response.Response-array_vaa_VaaDoc"
                         }
                     },
                     "400": {
@@ -2182,20 +2182,6 @@ const docTemplate = `{
                 }
             }
         },
-        "response.Response-array_vaa_VaaWithPayload": {
-            "type": "object",
-            "properties": {
-                "data": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/vaa.VaaWithPayload"
-                    }
-                },
-                "pagination": {
-                    "$ref": "#/definitions/response.ResponsePagination"
-                }
-            }
-        },
         "response.Response-governor_GovConfig": {
             "type": "object",
             "properties": {
@@ -2303,6 +2289,10 @@ const docTemplate = `{
         "vaa.VaaDoc": {
             "type": "object",
             "properties": {
+                "appId": {
+                    "description": "AppId is an extension field - it is not present in the guardian API.",
+                    "type": "string"
+                },
                 "emitterAddr": {
                     "type": "string"
                 },
@@ -2318,10 +2308,16 @@ const docTemplate = `{
                 "indexedAt": {
                     "type": "string"
                 },
+                "payload": {
+                    "description": "Payload is an extension field - it is not present in the guardian API.",
+                    "type": "object",
+                    "additionalProperties": true
+                },
                 "timestamp": {
                     "type": "string"
                 },
                 "txHash": {
+                    "description": "TxHash is an extension field - it is not present in the guardian API.",
                     "type": "string"
                 },
                 "updatedAt": {
@@ -2345,48 +2341,6 @@ const docTemplate = `{
                     "$ref": "#/definitions/vaa.ChainID"
                 },
                 "count": {
-                    "type": "integer"
-                }
-            }
-        },
-        "vaa.VaaWithPayload": {
-            "type": "object",
-            "properties": {
-                "appId": {
-                    "type": "string"
-                },
-                "emitterAddr": {
-                    "type": "string"
-                },
-                "emitterChain": {
-                    "$ref": "#/definitions/vaa.ChainID"
-                },
-                "guardianSetIndex": {
-                    "type": "integer"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "indexedAt": {
-                    "type": "string"
-                },
-                "payload": {
-                    "type": "object",
-                    "additionalProperties": true
-                },
-                "timestamp": {
-                    "type": "string"
-                },
-                "updatedAt": {
-                    "type": "string"
-                },
-                "vaa": {
-                    "type": "array",
-                    "items": {
-                        "type": "integer"
-                    }
-                },
-                "version": {
                     "type": "integer"
                 }
             }

--- a/api/docs/swagger.json
+++ b/api/docs/swagger.json
@@ -954,7 +954,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/response.Response-array_vaa_VaaWithPayload"
+                            "$ref": "#/definitions/response.Response-array_vaa_VaaDoc"
                         }
                     },
                     "400": {
@@ -1158,7 +1158,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/response.Response-array_vaa_VaaWithPayload"
+                            "$ref": "#/definitions/response.Response-array_vaa_VaaDoc"
                         }
                     },
                     "400": {
@@ -2175,20 +2175,6 @@
                 }
             }
         },
-        "response.Response-array_vaa_VaaWithPayload": {
-            "type": "object",
-            "properties": {
-                "data": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/vaa.VaaWithPayload"
-                    }
-                },
-                "pagination": {
-                    "$ref": "#/definitions/response.ResponsePagination"
-                }
-            }
-        },
         "response.Response-governor_GovConfig": {
             "type": "object",
             "properties": {
@@ -2296,6 +2282,10 @@
         "vaa.VaaDoc": {
             "type": "object",
             "properties": {
+                "appId": {
+                    "description": "AppId is an extension field - it is not present in the guardian API.",
+                    "type": "string"
+                },
                 "emitterAddr": {
                     "type": "string"
                 },
@@ -2311,10 +2301,16 @@
                 "indexedAt": {
                     "type": "string"
                 },
+                "payload": {
+                    "description": "Payload is an extension field - it is not present in the guardian API.",
+                    "type": "object",
+                    "additionalProperties": true
+                },
                 "timestamp": {
                     "type": "string"
                 },
                 "txHash": {
+                    "description": "TxHash is an extension field - it is not present in the guardian API.",
                     "type": "string"
                 },
                 "updatedAt": {
@@ -2338,48 +2334,6 @@
                     "$ref": "#/definitions/vaa.ChainID"
                 },
                 "count": {
-                    "type": "integer"
-                }
-            }
-        },
-        "vaa.VaaWithPayload": {
-            "type": "object",
-            "properties": {
-                "appId": {
-                    "type": "string"
-                },
-                "emitterAddr": {
-                    "type": "string"
-                },
-                "emitterChain": {
-                    "$ref": "#/definitions/vaa.ChainID"
-                },
-                "guardianSetIndex": {
-                    "type": "integer"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "indexedAt": {
-                    "type": "string"
-                },
-                "payload": {
-                    "type": "object",
-                    "additionalProperties": true
-                },
-                "timestamp": {
-                    "type": "string"
-                },
-                "updatedAt": {
-                    "type": "string"
-                },
-                "vaa": {
-                    "type": "array",
-                    "items": {
-                        "type": "integer"
-                    }
-                },
-                "version": {
                     "type": "integer"
                 }
             }

--- a/api/docs/swagger.yaml
+++ b/api/docs/swagger.yaml
@@ -435,15 +435,6 @@ definitions:
       pagination:
         $ref: '#/definitions/response.ResponsePagination'
     type: object
-  response.Response-array_vaa_VaaWithPayload:
-    properties:
-      data:
-        items:
-          $ref: '#/definitions/vaa.VaaWithPayload'
-        type: array
-      pagination:
-        $ref: '#/definitions/response.ResponsePagination'
-    type: object
   response.Response-governor_GovConfig:
     properties:
       data:
@@ -532,6 +523,10 @@ definitions:
     - ChainIDWormchain
   vaa.VaaDoc:
     properties:
+      appId:
+        description: AppId is an extension field - it is not present in the guardian
+          API.
+        type: string
       emitterAddr:
         type: string
       emitterChain:
@@ -542,9 +537,16 @@ definitions:
         type: string
       indexedAt:
         type: string
+      payload:
+        additionalProperties: true
+        description: Payload is an extension field - it is not present in the guardian
+          API.
+        type: object
       timestamp:
         type: string
       txHash:
+        description: TxHash is an extension field - it is not present in the guardian
+          API.
         type: string
       updatedAt:
         type: string
@@ -560,34 +562,6 @@ definitions:
       chainId:
         $ref: '#/definitions/vaa.ChainID'
       count:
-        type: integer
-    type: object
-  vaa.VaaWithPayload:
-    properties:
-      appId:
-        type: string
-      emitterAddr:
-        type: string
-      emitterChain:
-        $ref: '#/definitions/vaa.ChainID'
-      guardianSetIndex:
-        type: integer
-      id:
-        type: string
-      indexedAt:
-        type: string
-      payload:
-        additionalProperties: true
-        type: object
-      timestamp:
-        type: string
-      updatedAt:
-        type: string
-      vaa:
-        items:
-          type: integer
-        type: array
-      version:
         type: integer
     type: object
 info:
@@ -1221,7 +1195,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/response.Response-array_vaa_VaaWithPayload'
+            $ref: '#/definitions/response.Response-array_vaa_VaaDoc'
         "400":
           description: Bad Request
         "500":
@@ -1343,7 +1317,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/response.Response-array_vaa_VaaWithPayload'
+            $ref: '#/definitions/response.Response-array_vaa_VaaDoc'
         "400":
           description: Bad Request
         "500":

--- a/api/handlers/vaa/model.go
+++ b/api/handlers/vaa/model.go
@@ -13,7 +13,7 @@ const (
 	ChainIDPythNet vaa.ChainID = 26
 )
 
-// VaaDoc represent an vaa document.
+// VaaDoc defines the JSON model for VAA objects in the REST API.
 type VaaDoc struct {
 	ID               string      `bson:"_id" json:"id"`
 	Version          uint8       `bson:"version" json:"version"`
@@ -23,9 +23,14 @@ type VaaDoc struct {
 	GuardianSetIndex uint32      `bson:"guardianSetIndex" json:"guardianSetIndex"`
 	Vaa              []byte      `bson:"vaas" json:"vaa"`
 	Timestamp        *time.Time  `bson:"timestamp" json:"timestamp"`
-	TxHash           *string     `bson:"txHash" json:"txHash"`
 	UpdatedAt        *time.Time  `bson:"updatedAt" json:"updatedAt"`
 	IndexedAt        *time.Time  `bson:"indexedAt" json:"indexedAt"`
+	// TxHash is an extension field - it is not present in the guardian API.
+	TxHash *string `bson:"txHash" json:"txHash"`
+	// AppId is an extension field - it is not present in the guardian API.
+	AppId string `bson:"appId" json:"appId,omitempty"`
+	// Payload is an extension field - it is not present in the guardian API.
+	Payload map[string]interface{} `bson:"payload" json:"payload,omitempty"`
 }
 
 // MarshalJSON interface implementation.
@@ -49,20 +54,4 @@ func (v *VaaDoc) MarshalJSON() ([]byte, error) {
 type VaaStats struct {
 	ChainID vaa.ChainID `bson:"_id" json:"chainId"`
 	Count   int64       `bson:"count" json:"count"`
-}
-
-// VaaWithPayload vaa document with payload.
-type VaaWithPayload struct {
-	ID               string                 `bson:"_id" json:"id"`
-	Version          uint8                  `bson:"version" json:"version"`
-	EmitterChain     vaa.ChainID            `bson:"emitterChain" json:"emitterChain"`
-	EmitterAddr      string                 `bson:"emitterAddr" json:"emitterAddr"`
-	Sequence         string                 `bson:"sequence" json:"-"`
-	GuardianSetIndex uint32                 `bson:"guardianSetIndex" json:"guardianSetIndex"`
-	Vaa              []byte                 `bson:"vaas" json:"vaa"`
-	Timestamp        *time.Time             `bson:"timestamp" json:"timestamp"`
-	UpdatedAt        *time.Time             `bson:"updatedAt" json:"updatedAt"`
-	IndexedAt        *time.Time             `bson:"indexedAt" json:"indexedAt"`
-	AppId            string                 `bson:"appId" json:"appId,omitempty"`
-	Payload          map[string]interface{} `bson:"payload" json:"payload,omitempty"`
 }

--- a/api/routes/wormscan/vaa/controller.go
+++ b/api/routes/wormscan/vaa/controller.go
@@ -32,7 +32,7 @@ func NewController(serv *vaa.Service, logger *zap.Logger) *Controller {
 // @Param txHash query string false "Transaction hash of the VAA"
 // @Param parsedPayload query bool false "include the parsed contents of the VAA, if available"
 // @Param appId query string false "filter by application ID"
-// @Success 200 {object} response.Response[[]vaa.VaaWithPayload]
+// @Success 200 {object} response.Response[[]vaa.VaaDoc]
 // @Failure 400
 // @Failure 500
 // @Router /api/v1/vaas/ [get]
@@ -129,7 +129,7 @@ func (c *Controller) FindByEmitter(ctx *fiber.Ctx) error {
 // @Param signer path string true "Signer address"
 // @Param hash path string true "VAA hash"
 // @Param parsedPayload query bool false "include the parsed contents of the VAA, if available"
-// @Success 200 {object} response.Response[[]vaa.VaaWithPayload]
+// @Success 200 {object} response.Response[[]vaa.VaaDoc]
 // @Failure 400
 // @Failure 500
 // @Router /api/v1/vaas/{chain_id}/{emitter}/{seq}/{signer}/{hash} [get]


### PR DESCRIPTION
The structs `VaaDoc` and `VaaWithPayload` were being used for similar purposes.

This commit merges both into the same struct.