### PR TITLE
[API] Fix issue in MongoDB aggregation pipeline

### DIFF
--- a/api/handlers/vaa/repository.go
+++ b/api/handlers/vaa/repository.go
@@ -252,8 +252,8 @@ type VaaQuery struct {
 
 // Query create a new VaaQuery with default pagination vaues.
 func Query() *VaaQuery {
-	page := pagination.Default()
-	return &VaaQuery{Pagination: *page}
+	p := pagination.Default()
+	return &VaaQuery{Pagination: *p}
 }
 
 // SetChain set the chainId field of the VaaQuery struct.

--- a/api/handlers/vaa/service.go
+++ b/api/handlers/vaa/service.go
@@ -155,7 +155,11 @@ func (s *Service) findById(
 
 // findByIdWithPayload get a vaa with payload data by chainID, emitter address and sequence number.
 func (s *Service) findByIdWithPayload(ctx context.Context, chain vaa.ChainID, emitter vaa.Address, seq string) (*VaaDoc, error) {
-	query := Query().SetChain(chain).SetEmitter(emitter.String()).SetSequence(seq)
+
+	query := Query().
+		SetChain(chain).
+		SetEmitter(emitter.String()).
+		SetSequence(seq)
 
 	vaas, err := s.repo.FindVaasWithPayload(ctx, query)
 	if err != nil {

--- a/api/internal/pagination/pagination.go
+++ b/api/internal/pagination/pagination.go
@@ -10,7 +10,15 @@ type Pagination struct {
 
 // Default returns a `*Pagination` with default values.
 func Default() *Pagination {
-	return &Pagination{Skip: 0, Limit: 50}
+
+	p := &Pagination{
+		Skip:      0,
+		Limit:     50,
+		SortOrder: "DESC",
+		SortBy:    "indexedAt",
+	}
+
+	return p
 }
 
 // GetSortInt mapping to mongodb sort values.


### PR DESCRIPTION
### Summary

In some cases, the query parameters for a MongoDB aggregation pipeline were not being initialized.

This led to errors in `GET /api/v1/vaas/{chain}/{emitter}/{seq}`. Other endpoints could also have been affected.