### PR TITLE
[API] Change status code for enqueued VAAs endpoint

### DIFF
--- a/api/handlers/governor/repository.go
+++ b/api/handlers/governor/repository.go
@@ -784,10 +784,6 @@ func (r *Repository) GetEnqueueVass(ctx context.Context, q *EnqueuedVaaQuery) ([
 		return nil, errors.WithStack(err)
 	}
 
-	if len(rows) == 0 {
-		return nil, errs.ErrNotFound
-	}
-
 	// TODO: Change this logic to mongo query code.
 	// proecess and build the response.
 	keys := map[string]string{}
@@ -813,10 +809,6 @@ func (r *Repository) GetEnqueueVass(ctx context.Context, q *EnqueuedVaaQuery) ([
 				}
 			}
 		}
-	}
-
-	if len(enqueuedVaas) == 0 {
-		return nil, errs.ErrNotFound
 	}
 
 	// group by chainID.

--- a/api/routes/wormscan/governor/controller.go
+++ b/api/routes/wormscan/governor/controller.go
@@ -305,7 +305,7 @@ func (c *Controller) GetMaxNotionalAvailableByChainID(ctx *fiber.Ctx) error {
 	return ctx.JSON(response)
 }
 
-// GetEnqueueVaas godoc
+// GetEnqueuedVaas godoc
 // @Description Returns enqueued VAAs for each blockchain.
 // @Tags Wormscan
 // @ID governor-enqueued-vaas
@@ -316,7 +316,7 @@ func (c *Controller) GetMaxNotionalAvailableByChainID(ctx *fiber.Ctx) error {
 // @Failure 400
 // @Failure 500
 // @Router /api/v1/governor/enqueued_vaas/ [get]
-func (c *Controller) GetEnqueueVaas(ctx *fiber.Ctx) error {
+func (c *Controller) GetEnqueuedVaas(ctx *fiber.Ctx) error {
 
 	p, err := middleware.ExtractPagination(ctx)
 	if err != nil {

--- a/api/routes/wormscan/routes.go
+++ b/api/routes/wormscan/routes.go
@@ -89,6 +89,6 @@ func RegisterRoutes(
 	governorNotional.Get("/max_available/:chain", governorCtrl.GetMaxNotionalAvailableByChainID)
 
 	enqueueVaas := governor.Group("/enqueued_vaas")
-	enqueueVaas.Get("/", governorCtrl.GetEnqueueVaas)
+	enqueueVaas.Get("/", governorCtrl.GetEnqueuedVaas)
 	enqueueVaas.Get("/:chain", governorCtrl.GetEnqueuedVaasByChainID)
 }


### PR DESCRIPTION
### Summary

Previously, when calling `GET /api/v1/governor/enqueued_vaas`, it returned a status code of 404 when there were no enqueued VAAs.

Now, the endpoint returns a status code of 200, and the response body contains an empty array.
