### PR TITLE
[API] Several fixes in `GET /api/v1/governor/limit`

### DIFF
--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -231,16 +231,6 @@ const docTemplate = `{
                         "description": "Number of elements per page.",
                         "name": "pageSize",
                         "in": "query"
-                    },
-                    {
-                        "enum": [
-                            "ASC",
-                            "DESC"
-                        ],
-                        "type": "string",
-                        "description": "Sort results in ascending or descending order.",
-                        "name": "sortOrder",
-                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -1970,7 +1960,7 @@ const docTemplate = `{
                 "build": {
                     "type": "string"
                 },
-                "buildDate": {
+                "build_date": {
                     "type": "string"
                 },
                 "machine": {

--- a/api/docs/swagger.json
+++ b/api/docs/swagger.json
@@ -224,16 +224,6 @@
                         "description": "Number of elements per page.",
                         "name": "pageSize",
                         "in": "query"
-                    },
-                    {
-                        "enum": [
-                            "ASC",
-                            "DESC"
-                        ],
-                        "type": "string",
-                        "description": "Sort results in ascending or descending order.",
-                        "name": "sortOrder",
-                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -1963,7 +1953,7 @@
                 "build": {
                     "type": "string"
                 },
-                "buildDate": {
+                "build_date": {
                     "type": "string"
                 },
                 "machine": {

--- a/api/docs/swagger.yaml
+++ b/api/docs/swagger.yaml
@@ -307,7 +307,7 @@ definitions:
         type: string
       build:
         type: string
-      buildDate:
+      build_date:
         type: string
       machine:
         type: string
@@ -717,13 +717,6 @@ paths:
         in: query
         name: pageSize
         type: integer
-      - description: Sort results in ascending or descending order.
-        enum:
-        - ASC
-        - DESC
-        in: query
-        name: sortOrder
-        type: string
       responses:
         "200":
           description: OK

--- a/api/handlers/governor/repository.go
+++ b/api/handlers/governor/repository.go
@@ -1117,11 +1117,6 @@ func (r *Repository) GetGovernorLimit(ctx context.Context, q *GovernorQuery) ([]
 		return nil, errors.WithStack(err)
 	}
 
-	// check exists records
-	if len(governorLimits) == 0 {
-		return nil, errs.ErrNotFound
-	}
-
 	return governorLimits, nil
 }
 

--- a/api/routes/wormscan/governor/controller.go
+++ b/api/routes/wormscan/governor/controller.go
@@ -140,7 +140,6 @@ func (c *Controller) FindGovernorStatusByGuardianAddress(ctx *fiber.Ctx) error {
 // @ID governor-notional-limit
 // @Param page query integer false "Page number."
 // @Param pageSize query integer false "Number of elements per page."
-// @Param sortOrder query string false "Sort results in ascending or descending order." Enums(ASC, DESC)
 // @Success 200 {object} response.Response[[]GovernorLimit]
 // @Failure 400
 // @Failure 500


### PR DESCRIPTION
### Summary

Changes to `GET /api/v1/governor/limit`:
* Fix the behavior of the parameters `page` and `pageSize` (which previously were being ignored).
* When no results are found, return an HTTP status code of 200 and set the response to an empty array.
* Remove the `sortOrder` query parameter.

The rationale for removing the `sortOrder` parameter is that sorting chains by ascending/descending chain ID doesn't seem to be a useful operation.