### PR TITLE
[API] Fix incorrect route in swagger docs

### DIFF
--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -249,53 +249,6 @@ const docTemplate = `{
                 }
             }
         },
-        "/api/v1/governor/max_available/:chain": {
-            "get": {
-                "description": "Returns the maximum amount of notional value available for a given blockchain.",
-                "tags": [
-                    "Wormscan"
-                ],
-                "operationId": "governor-max-notional-available-by-chain",
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "Page number.",
-                        "name": "page",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Number of elements per page.",
-                        "name": "pageSize",
-                        "in": "query"
-                    },
-                    {
-                        "enum": [
-                            "ASC",
-                            "DESC"
-                        ],
-                        "type": "string",
-                        "description": "Sort results in ascending or descending order.",
-                        "name": "sortOrder",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/response.Response-governor_MaxNotionalAvailableRecord"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request"
-                    },
-                    "500": {
-                        "description": "Internal Server Error"
-                    }
-                }
-            }
-        },
         "/api/v1/governor/notional/available": {
             "get": {
                 "description": "Returns the amount of notional value available for each blockchain.",
@@ -473,6 +426,53 @@ const docTemplate = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/response.Response-array_governor_NotionalLimitDetail"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            }
+        },
+        "/api/v1/governor/notional/max_available/:chain": {
+            "get": {
+                "description": "Returns the maximum amount of notional value available for a given blockchain.",
+                "tags": [
+                    "Wormscan"
+                ],
+                "operationId": "governor-max-notional-available-by-chain",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Page number.",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Number of elements per page.",
+                        "name": "pageSize",
+                        "in": "query"
+                    },
+                    {
+                        "enum": [
+                            "ASC",
+                            "DESC"
+                        ],
+                        "type": "string",
+                        "description": "Sort results in ascending or descending order.",
+                        "name": "sortOrder",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/response.Response-governor_MaxNotionalAvailableRecord"
                         }
                     },
                     "400": {

--- a/api/docs/swagger.json
+++ b/api/docs/swagger.json
@@ -242,53 +242,6 @@
                 }
             }
         },
-        "/api/v1/governor/max_available/:chain": {
-            "get": {
-                "description": "Returns the maximum amount of notional value available for a given blockchain.",
-                "tags": [
-                    "Wormscan"
-                ],
-                "operationId": "governor-max-notional-available-by-chain",
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "Page number.",
-                        "name": "page",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Number of elements per page.",
-                        "name": "pageSize",
-                        "in": "query"
-                    },
-                    {
-                        "enum": [
-                            "ASC",
-                            "DESC"
-                        ],
-                        "type": "string",
-                        "description": "Sort results in ascending or descending order.",
-                        "name": "sortOrder",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/response.Response-governor_MaxNotionalAvailableRecord"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request"
-                    },
-                    "500": {
-                        "description": "Internal Server Error"
-                    }
-                }
-            }
-        },
         "/api/v1/governor/notional/available": {
             "get": {
                 "description": "Returns the amount of notional value available for each blockchain.",
@@ -466,6 +419,53 @@
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/response.Response-array_governor_NotionalLimitDetail"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            }
+        },
+        "/api/v1/governor/notional/max_available/:chain": {
+            "get": {
+                "description": "Returns the maximum amount of notional value available for a given blockchain.",
+                "tags": [
+                    "Wormscan"
+                ],
+                "operationId": "governor-max-notional-available-by-chain",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Page number.",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Number of elements per page.",
+                        "name": "pageSize",
+                        "in": "query"
+                    },
+                    {
+                        "enum": [
+                            "ASC",
+                            "DESC"
+                        ],
+                        "type": "string",
+                        "description": "Sort results in ascending or descending order.",
+                        "name": "sortOrder",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/response.Response-governor_MaxNotionalAvailableRecord"
                         }
                     },
                     "400": {

--- a/api/docs/swagger.yaml
+++ b/api/docs/swagger.yaml
@@ -728,38 +728,6 @@ paths:
           description: Internal Server Error
       tags:
       - Wormscan
-  /api/v1/governor/max_available/:chain:
-    get:
-      description: Returns the maximum amount of notional value available for a given
-        blockchain.
-      operationId: governor-max-notional-available-by-chain
-      parameters:
-      - description: Page number.
-        in: query
-        name: page
-        type: integer
-      - description: Number of elements per page.
-        in: query
-        name: pageSize
-        type: integer
-      - description: Sort results in ascending or descending order.
-        enum:
-        - ASC
-        - DESC
-        in: query
-        name: sortOrder
-        type: string
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/response.Response-governor_MaxNotionalAvailableRecord'
-        "400":
-          description: Bad Request
-        "500":
-          description: Internal Server Error
-      tags:
-      - Wormscan
   /api/v1/governor/notional/available:
     get:
       description: Returns the amount of notional value available for each blockchain.
@@ -878,6 +846,38 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/response.Response-array_governor_NotionalLimitDetail'
+        "400":
+          description: Bad Request
+        "500":
+          description: Internal Server Error
+      tags:
+      - Wormscan
+  /api/v1/governor/notional/max_available/:chain:
+    get:
+      description: Returns the maximum amount of notional value available for a given
+        blockchain.
+      operationId: governor-max-notional-available-by-chain
+      parameters:
+      - description: Page number.
+        in: query
+        name: page
+        type: integer
+      - description: Number of elements per page.
+        in: query
+        name: pageSize
+        type: integer
+      - description: Sort results in ascending or descending order.
+        enum:
+        - ASC
+        - DESC
+        in: query
+        name: sortOrder
+        type: string
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/response.Response-governor_MaxNotionalAvailableRecord'
         "400":
           description: Bad Request
         "500":

--- a/api/routes/wormscan/governor/controller.go
+++ b/api/routes/wormscan/governor/controller.go
@@ -283,7 +283,7 @@ func (c *Controller) GetAvailableNotionalByChainID(ctx *fiber.Ctx) error {
 // @Success 200 {object} response.Response[MaxNotionalAvailableRecord]
 // @Failure 400
 // @Failure 500
-// @Router /api/v1/governor/max_available/:chain [get]
+// @Router /api/v1/governor/notional/max_available/:chain [get]
 func (c *Controller) GetMaxNotionalAvailableByChainID(ctx *fiber.Ctx) error {
 
 	p, err := middleware.ExtractPagination(ctx)


### PR DESCRIPTION
### Summary

The API's swagger documentation exposes a route `GET /api/v1/governor/max_available/:chain`, but instead it should be `GET /api/v1/governor/notional/max_available/:chain`.