### PR TITLE
[API] Remove unused query params from swagger docs

### DIFF
--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -43,16 +43,6 @@ const docTemplate = `{
                         "description": "Number of elements per page.",
                         "name": "pageSize",
                         "in": "query"
-                    },
-                    {
-                        "enum": [
-                            "ASC",
-                            "DESC"
-                        ],
-                        "type": "string",
-                        "description": "Sort results in ascending or descending order.",
-                        "name": "sortOrder",
-                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -78,35 +68,11 @@ const docTemplate = `{
                     "Wormscan"
                 ],
                 "operationId": "governor-config-by-guardian-address",
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "Page number.",
-                        "name": "page",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Number of elements per page.",
-                        "name": "pageSize",
-                        "in": "query"
-                    },
-                    {
-                        "enum": [
-                            "ASC",
-                            "DESC"
-                        ],
-                        "type": "string",
-                        "description": "Sort results in ascending or descending order.",
-                        "name": "sortOrder",
-                        "in": "query"
-                    }
-                ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/response.Response-array_governor_GovConfig"
+                            "$ref": "#/definitions/response.Response-governor_GovConfig"
                         }
                     },
                     "400": {
@@ -2039,20 +2005,6 @@ const docTemplate = `{
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/governor.EnqueuedVaas"
-                    }
-                },
-                "pagination": {
-                    "$ref": "#/definitions/response.ResponsePagination"
-                }
-            }
-        },
-        "response.Response-array_governor_GovConfig": {
-            "type": "object",
-            "properties": {
-                "data": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/governor.GovConfig"
                     }
                 },
                 "pagination": {

--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -281,16 +281,6 @@ const docTemplate = `{
                         "description": "Number of elements per page.",
                         "name": "pageSize",
                         "in": "query"
-                    },
-                    {
-                        "enum": [
-                            "ASC",
-                            "DESC"
-                        ],
-                        "type": "string",
-                        "description": "Sort results in ascending or descending order.",
-                        "name": "sortOrder",
-                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -327,16 +317,6 @@ const docTemplate = `{
                         "type": "integer",
                         "description": "Number of elements per page.",
                         "name": "pageSize",
-                        "in": "query"
-                    },
-                    {
-                        "enum": [
-                            "ASC",
-                            "DESC"
-                        ],
-                        "type": "string",
-                        "description": "Sort results in ascending or descending order.",
-                        "name": "sortOrder",
                         "in": "query"
                     }
                 ],
@@ -375,16 +355,6 @@ const docTemplate = `{
                         "description": "Number of elements per page.",
                         "name": "pageSize",
                         "in": "query"
-                    },
-                    {
-                        "enum": [
-                            "ASC",
-                            "DESC"
-                        ],
-                        "type": "string",
-                        "description": "Sort results in ascending or descending order.",
-                        "name": "sortOrder",
-                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -410,30 +380,6 @@ const docTemplate = `{
                     "Wormscan"
                 ],
                 "operationId": "governor-max-notional-available-by-chain",
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "Page number.",
-                        "name": "page",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Number of elements per page.",
-                        "name": "pageSize",
-                        "in": "query"
-                    },
-                    {
-                        "enum": [
-                            "ASC",
-                            "DESC"
-                        ],
-                        "type": "string",
-                        "description": "Sort results in ascending or descending order.",
-                        "name": "sortOrder",
-                        "in": "query"
-                    }
-                ],
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -468,16 +414,6 @@ const docTemplate = `{
                         "type": "integer",
                         "description": "Number of elements per page.",
                         "name": "pageSize",
-                        "in": "query"
-                    },
-                    {
-                        "enum": [
-                            "ASC",
-                            "DESC"
-                        ],
-                        "type": "string",
-                        "description": "Sort results in ascending or descending order.",
-                        "name": "sortOrder",
                         "in": "query"
                     }
                 ],
@@ -515,16 +451,6 @@ const docTemplate = `{
                         "type": "integer",
                         "description": "Number of elements per page.",
                         "name": "pageSize",
-                        "in": "query"
-                    },
-                    {
-                        "enum": [
-                            "ASC",
-                            "DESC"
-                        ],
-                        "type": "string",
-                        "description": "Sort results in ascending or descending order.",
-                        "name": "sortOrder",
                         "in": "query"
                     }
                 ],

--- a/api/docs/swagger.json
+++ b/api/docs/swagger.json
@@ -36,16 +36,6 @@
                         "description": "Number of elements per page.",
                         "name": "pageSize",
                         "in": "query"
-                    },
-                    {
-                        "enum": [
-                            "ASC",
-                            "DESC"
-                        ],
-                        "type": "string",
-                        "description": "Sort results in ascending or descending order.",
-                        "name": "sortOrder",
-                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -71,35 +61,11 @@
                     "Wormscan"
                 ],
                 "operationId": "governor-config-by-guardian-address",
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "Page number.",
-                        "name": "page",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Number of elements per page.",
-                        "name": "pageSize",
-                        "in": "query"
-                    },
-                    {
-                        "enum": [
-                            "ASC",
-                            "DESC"
-                        ],
-                        "type": "string",
-                        "description": "Sort results in ascending or descending order.",
-                        "name": "sortOrder",
-                        "in": "query"
-                    }
-                ],
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/response.Response-array_governor_GovConfig"
+                            "$ref": "#/definitions/response.Response-governor_GovConfig"
                         }
                     },
                     "400": {
@@ -2032,20 +1998,6 @@
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/governor.EnqueuedVaas"
-                    }
-                },
-                "pagination": {
-                    "$ref": "#/definitions/response.ResponsePagination"
-                }
-            }
-        },
-        "response.Response-array_governor_GovConfig": {
-            "type": "object",
-            "properties": {
-                "data": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/governor.GovConfig"
                     }
                 },
                 "pagination": {

--- a/api/docs/swagger.json
+++ b/api/docs/swagger.json
@@ -274,16 +274,6 @@
                         "description": "Number of elements per page.",
                         "name": "pageSize",
                         "in": "query"
-                    },
-                    {
-                        "enum": [
-                            "ASC",
-                            "DESC"
-                        ],
-                        "type": "string",
-                        "description": "Sort results in ascending or descending order.",
-                        "name": "sortOrder",
-                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -320,16 +310,6 @@
                         "type": "integer",
                         "description": "Number of elements per page.",
                         "name": "pageSize",
-                        "in": "query"
-                    },
-                    {
-                        "enum": [
-                            "ASC",
-                            "DESC"
-                        ],
-                        "type": "string",
-                        "description": "Sort results in ascending or descending order.",
-                        "name": "sortOrder",
                         "in": "query"
                     }
                 ],
@@ -368,16 +348,6 @@
                         "description": "Number of elements per page.",
                         "name": "pageSize",
                         "in": "query"
-                    },
-                    {
-                        "enum": [
-                            "ASC",
-                            "DESC"
-                        ],
-                        "type": "string",
-                        "description": "Sort results in ascending or descending order.",
-                        "name": "sortOrder",
-                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -403,30 +373,6 @@
                     "Wormscan"
                 ],
                 "operationId": "governor-max-notional-available-by-chain",
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "Page number.",
-                        "name": "page",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Number of elements per page.",
-                        "name": "pageSize",
-                        "in": "query"
-                    },
-                    {
-                        "enum": [
-                            "ASC",
-                            "DESC"
-                        ],
-                        "type": "string",
-                        "description": "Sort results in ascending or descending order.",
-                        "name": "sortOrder",
-                        "in": "query"
-                    }
-                ],
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -461,16 +407,6 @@
                         "type": "integer",
                         "description": "Number of elements per page.",
                         "name": "pageSize",
-                        "in": "query"
-                    },
-                    {
-                        "enum": [
-                            "ASC",
-                            "DESC"
-                        ],
-                        "type": "string",
-                        "description": "Sort results in ascending or descending order.",
-                        "name": "sortOrder",
                         "in": "query"
                     }
                 ],
@@ -508,16 +444,6 @@
                         "type": "integer",
                         "description": "Number of elements per page.",
                         "name": "pageSize",
-                        "in": "query"
-                    },
-                    {
-                        "enum": [
-                            "ASC",
-                            "DESC"
-                        ],
-                        "type": "string",
-                        "description": "Sort results in ascending or descending order.",
-                        "name": "sortOrder",
                         "in": "query"
                     }
                 ],

--- a/api/docs/swagger.yaml
+++ b/api/docs/swagger.yaml
@@ -363,15 +363,6 @@ definitions:
       pagination:
         $ref: '#/definitions/response.ResponsePagination'
     type: object
-  response.Response-array_governor_GovConfig:
-    properties:
-      data:
-        items:
-          $ref: '#/definitions/governor.GovConfig'
-        type: array
-      pagination:
-        $ref: '#/definitions/response.ResponsePagination'
-    type: object
   response.Response-array_governor_GovStatus:
     properties:
       data:
@@ -593,13 +584,6 @@ paths:
         in: query
         name: pageSize
         type: integer
-      - description: Sort results in ascending or descending order.
-        enum:
-        - ASC
-        - DESC
-        in: query
-        name: sortOrder
-        type: string
       responses:
         "200":
           description: OK
@@ -615,27 +599,11 @@ paths:
     get:
       description: Returns governor configuration for a given guardian.
       operationId: governor-config-by-guardian-address
-      parameters:
-      - description: Page number.
-        in: query
-        name: page
-        type: integer
-      - description: Number of elements per page.
-        in: query
-        name: pageSize
-        type: integer
-      - description: Sort results in ascending or descending order.
-        enum:
-        - ASC
-        - DESC
-        in: query
-        name: sortOrder
-        type: string
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/response.Response-array_governor_GovConfig'
+            $ref: '#/definitions/response.Response-governor_GovConfig'
         "400":
           description: Bad Request
         "500":

--- a/api/docs/swagger.yaml
+++ b/api/docs/swagger.yaml
@@ -740,13 +740,6 @@ paths:
         in: query
         name: pageSize
         type: integer
-      - description: Sort results in ascending or descending order.
-        enum:
-        - ASC
-        - DESC
-        in: query
-        name: sortOrder
-        type: string
       responses:
         "200":
           description: OK
@@ -771,13 +764,6 @@ paths:
         in: query
         name: pageSize
         type: integer
-      - description: Sort results in ascending or descending order.
-        enum:
-        - ASC
-        - DESC
-        in: query
-        name: sortOrder
-        type: string
       responses:
         "200":
           description: OK
@@ -802,13 +788,6 @@ paths:
         in: query
         name: pageSize
         type: integer
-      - description: Sort results in ascending or descending order.
-        enum:
-        - ASC
-        - DESC
-        in: query
-        name: sortOrder
-        type: string
       responses:
         "200":
           description: OK
@@ -825,22 +804,6 @@ paths:
       description: Returns the maximum amount of notional value available for a given
         blockchain.
       operationId: governor-max-notional-available-by-chain
-      parameters:
-      - description: Page number.
-        in: query
-        name: page
-        type: integer
-      - description: Number of elements per page.
-        in: query
-        name: pageSize
-        type: integer
-      - description: Sort results in ascending or descending order.
-        enum:
-        - ASC
-        - DESC
-        in: query
-        name: sortOrder
-        type: string
       responses:
         "200":
           description: OK
@@ -865,13 +828,6 @@ paths:
         in: query
         name: pageSize
         type: integer
-      - description: Sort results in ascending or descending order.
-        enum:
-        - ASC
-        - DESC
-        in: query
-        name: sortOrder
-        type: string
       responses:
         "200":
           description: OK
@@ -896,13 +852,6 @@ paths:
         in: query
         name: pageSize
         type: integer
-      - description: Sort results in ascending or descending order.
-        enum:
-        - ASC
-        - DESC
-        in: query
-        name: sortOrder
-        type: string
       responses:
         "200":
           description: OK

--- a/api/handlers/governor/repository.go
+++ b/api/handlers/governor/repository.go
@@ -88,48 +88,38 @@ func (r *Repository) FindGovConfigurations(ctx context.Context, q *GovernorQuery
 		{Key: "chains", Value: "$parsedConfig.chains"},
 		{Key: "tokens", Value: "$parsedConfig.tokens"},
 	}
-	options := options.Find().SetProjection(projection).SetLimit(q.Limit).SetSkip(q.Skip).SetSort(sort)
+
+	options := options.
+		Find().
+		SetProjection(projection).
+		SetLimit(q.Limit).
+		SetSkip(q.Skip).
+		SetSort(sort)
+
 	cur, err := r.collections.governorConfig.Find(ctx, q.toBSON(), options)
 	if err != nil {
 		requestID := fmt.Sprintf("%v", ctx.Value("requestid"))
 		r.logger.Error("failed execute Find command to get governor configurations",
-			zap.Error(err), zap.Any("q", q), zap.String("requestID", requestID))
+			zap.Error(err),
+			zap.Any("q", q),
+			zap.String("requestID", requestID),
+		)
 		return nil, errors.WithStack(err)
 	}
+
 	var govConfigs []*GovConfig
 	err = cur.All(ctx, &govConfigs)
 	if err != nil {
 		requestID := fmt.Sprintf("%v", ctx.Value("requestid"))
-		r.logger.Error("failed decoding cursor to []*GovConfig", zap.Error(err), zap.Any("q", q),
-			zap.String("requestID", requestID))
+		r.logger.Error("failed decoding cursor to []*GovConfig",
+			zap.Error(err),
+			zap.Any("q", q),
+			zap.String("requestID", requestID),
+		)
 		return nil, errors.WithStack(err)
 	}
-	return govConfigs, err
-}
 
-// FindGovConfiguration get a *GovConfig. The q parameter define the filter to apply to the query.
-func (r *Repository) FindGovConfiguration(ctx context.Context, q *GovernorQuery) (*GovConfig, error) {
-	var govConfig GovConfig
-	projection := bson.D{
-		{Key: "createdAt", Value: 1},
-		{Key: "updatedAt", Value: 1},
-		{Key: "nodename", Value: "$parsedConfig.nodename"},
-		{Key: "counter", Value: "$parsedConfig.counter"},
-		{Key: "chains", Value: "$parsedConfig.chains"},
-		{Key: "tokens", Value: "$parsedConfig.tokens"},
-	}
-	options := options.FindOne().SetProjection(projection)
-	err := r.collections.governorConfig.FindOne(ctx, q.toBSON(), options).Decode(&govConfig)
-	if err != nil {
-		if errors.Is(err, mongo.ErrNoDocuments) {
-			return nil, errs.ErrNotFound
-		}
-		requestID := fmt.Sprintf("%v", ctx.Value("requestid"))
-		r.logger.Error("failed execute FindOne command to get governor configuration",
-			zap.Error(err), zap.Any("q", q), zap.String("requestID", requestID))
-		return nil, errors.WithStack(err)
-	}
-	return &govConfig, err
+	return govConfigs, err
 }
 
 // FindGovernorStatus get a list of *GovStatus.

--- a/api/handlers/governor/repository.go
+++ b/api/handlers/governor/repository.go
@@ -77,7 +77,9 @@ func (q *GovernorQuery) toBSON() *bson.D {
 
 // FindGovConfigurations get a list of *GovConfig.
 func (r *Repository) FindGovConfigurations(ctx context.Context, q *GovernorQuery) ([]*GovConfig, error) {
-	sort := bson.D{{Key: q.SortBy, Value: q.GetSortInt()}}
+
+	sort := bson.D{{Key: "_id", Value: 1}}
+
 	projection := bson.D{
 		{Key: "createdAt", Value: 1},
 		{Key: "updatedAt", Value: 1},

--- a/api/handlers/governor/service.go
+++ b/api/handlers/governor/service.go
@@ -33,11 +33,21 @@ func (s *Service) FindGovernorConfig(ctx context.Context, p *pagination.Paginati
 }
 
 // FindGovernorConfigByGuardianAddress get a governor configuration by guardianAddress.
-func (s *Service) FindGovernorConfigByGuardianAddress(ctx context.Context, guardianAddress string, p *pagination.Pagination) (*response.Response[*GovConfig], error) {
-	query := QueryGovernor().SetID(guardianAddress).SetPagination(p)
-	govConfig, err := s.repo.FindGovConfiguration(ctx, query)
-	res := response.Response[*GovConfig]{Data: govConfig}
-	return &res, err
+func (s *Service) FindGovernorConfigByGuardianAddress(
+	ctx context.Context,
+	guardianAddress string,
+) ([]*GovConfig, error) {
+
+	p := pagination.
+		Default().
+		SetLimit(1)
+
+	query := QueryGovernor().
+		SetID(guardianAddress).
+		SetPagination(p)
+
+	govConfigs, err := s.repo.FindGovConfigurations(ctx, query)
+	return govConfigs, err
 }
 
 // FindGovernorStatus get a list of governor status.

--- a/api/handlers/governor/service.go
+++ b/api/handlers/governor/service.go
@@ -108,8 +108,8 @@ func (s *Service) GetAvailableNotionalByChainID(ctx context.Context, p *paginati
 }
 
 // GetMaxNotionalAvailableByChainID get a maximun notional value by chainID.
-func (s *Service) GetMaxNotionalAvailableByChainID(ctx context.Context, p *pagination.Pagination, chainID vaa.ChainID) (*response.Response[*MaxNotionalAvailableRecord], error) {
-	query := QueryNotionalLimit().SetPagination(p).SetChain(chainID)
+func (s *Service) GetMaxNotionalAvailableByChainID(ctx context.Context, chainID vaa.ChainID) (*response.Response[*MaxNotionalAvailableRecord], error) {
+	query := QueryNotionalLimit().SetChain(chainID)
 	maxNotionaLAvailable, err := s.repo.GetMaxNotionalAvailableByChainID(ctx, query)
 	res := response.Response[*MaxNotionalAvailableRecord]{Data: maxNotionaLAvailable}
 	return &res, err

--- a/api/internal/pagination/pagination.go
+++ b/api/internal/pagination/pagination.go
@@ -21,6 +21,26 @@ func Default() *Pagination {
 	return p
 }
 
+func (p *Pagination) SetSkip(skip int64) *Pagination {
+	p.Skip = skip
+	return p
+}
+
+func (p *Pagination) SetLimit(limit int64) *Pagination {
+	p.Limit = limit
+	return p
+}
+
+func (p *Pagination) SetSortOrder(sortOrder string) *Pagination {
+	p.SortOrder = sortOrder
+	return p
+}
+
+func (p *Pagination) SetSortBy(sortBy string) *Pagination {
+	p.SortBy = sortBy
+	return p
+}
+
 // GetSortInt mapping to mongodb sort values.
 func (p *Pagination) GetSortInt() int {
 	if p.SortOrder == "ASC" {

--- a/api/routes/wormscan/governor/controller.go
+++ b/api/routes/wormscan/governor/controller.go
@@ -29,7 +29,6 @@ func NewController(serv *governor.Service, logger *zap.Logger) *Controller {
 // @ID governor-config
 // @Param page query integer false "Page number."
 // @Param pageSize query integer false "Number of elements per page."
-// @Param sortOrder query string false "Sort results in ascending or descending order." Enums(ASC, DESC)
 // @Success 200 {object} response.Response[GovConfig]
 // @Failure 400
 // @Failure 500
@@ -53,10 +52,7 @@ func (c *Controller) FindGovernorConfigurations(ctx *fiber.Ctx) error {
 // @Description Returns governor configuration for a given guardian.
 // @Tags Wormscan
 // @ID governor-config-by-guardian-address
-// @Param page query integer false "Page number."
-// @Param pageSize query integer false "Number of elements per page."
-// @Param sortOrder query string false "Sort results in ascending or descending order." Enums(ASC, DESC)
-// @Success 200 {object} response.Response[[]GovConfig]
+// @Success 200 {object} response.Response[GovConfig]
 // @Failure 400
 // @Failure 500
 // @Router /api/v1/governor/config/:guardian_address [get]

--- a/api/routes/wormscan/governor/controller.go
+++ b/api/routes/wormscan/governor/controller.go
@@ -86,7 +86,6 @@ func (c *Controller) FindGovernorConfigurationByGuardianAddress(ctx *fiber.Ctx) 
 // @ID governor-status
 // @Param page query integer false "Page number."
 // @Param pageSize query integer false "Number of elements per page."
-// @Param sortOrder query string false "Sort results in ascending or descending order." Enums(ASC, DESC)
 // @Success 200 {object} response.Response[[]GovStatus]
 // @Failure 400
 // @Failure 500
@@ -112,7 +111,6 @@ func (c *Controller) FindGovernorStatus(ctx *fiber.Ctx) error {
 // @ID governor-status-by-guardian-address
 // @Param page query integer false "Page number."
 // @Param pageSize query integer false "Number of elements per page."
-// @Param sortOrder query string false "Sort results in ascending or descending order." Enums(ASC, DESC)
 // @Success 200 {object} response.Response[GovStatus]
 // @Failure 400
 // @Failure 500
@@ -168,7 +166,6 @@ func (c *Controller) GetGovernorLimit(ctx *fiber.Ctx) error {
 // @ID governor-notional-limit-detail
 // @Param page query integer false "Page number."
 // @Param pageSize query integer false "Number of elements per page."
-// @Param sortOrder query string false "Sort results in ascending or descending order." Enums(ASC, DESC)
 // @Success 200 {object} response.Response[[]NotionalLimitDetail]
 // @Failure 400
 // @Failure 500
@@ -194,7 +191,6 @@ func (c *Controller) FindNotionalLimit(ctx *fiber.Ctx) error {
 // @ID governor-notional-limit-detail-by-chain
 // @Param page query integer false "Page number."
 // @Param pageSize query integer false "Number of elements per page."
-// @Param sortOrder query string false "Sort results in ascending or descending order." Enums(ASC, DESC)
 // @Success 200 {object} response.Response[[]NotionalLimitDetail]
 // @Failure 400
 // @Failure 500
@@ -251,7 +247,6 @@ func (c *Controller) GetAvailableNotional(ctx *fiber.Ctx) error {
 // @ID governor-notional-available-by-chain
 // @Param page query integer false "Page number."
 // @Param pageSize query integer false "Number of elements per page."
-// @Param sortOrder query string false "Sort results in ascending or descending order." Enums(ASC, DESC)
 // @Success 200 {object} response.Response[[]NotionalAvailableDetail]
 // @Failure 400
 // @Failure 500
@@ -280,26 +275,18 @@ func (c *Controller) GetAvailableNotionalByChainID(ctx *fiber.Ctx) error {
 // @Description Returns the maximum amount of notional value available for a given blockchain.
 // @Tags Wormscan
 // @ID governor-max-notional-available-by-chain
-// @Param page query integer false "Page number."
-// @Param pageSize query integer false "Number of elements per page."
-// @Param sortOrder query string false "Sort results in ascending or descending order." Enums(ASC, DESC)
 // @Success 200 {object} response.Response[MaxNotionalAvailableRecord]
 // @Failure 400
 // @Failure 500
 // @Router /api/v1/governor/notional/max_available/:chain [get]
 func (c *Controller) GetMaxNotionalAvailableByChainID(ctx *fiber.Ctx) error {
 
-	p, err := middleware.ExtractPagination(ctx)
-	if err != nil {
-		return err
-	}
-
 	chainID, err := middleware.ExtractChainID(ctx, c.logger)
 	if err != nil {
 		return err
 	}
 
-	response, err := c.srv.GetMaxNotionalAvailableByChainID(ctx.Context(), p, chainID)
+	response, err := c.srv.GetMaxNotionalAvailableByChainID(ctx.Context(), chainID)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Summary

* Swagger: remove `sortOrder` query parameter from several endpoints in which it didn't make sense.
* Swagger: remove query params `page` and `pageSize` from endpoints that return a single object.
* Sort the output of `GET /api/v1/governor/config` by ascending id.
* Refactor: remove duplicated code, format code for readability.