### PR TITLE
[API] Accept additional address formats

### DIFF
--- a/api/handlers/governor/repository.go
+++ b/api/handlers/governor/repository.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pkg/errors"
 	errs "github.com/wormhole-foundation/wormhole-explorer/api/internal/errors"
 	"github.com/wormhole-foundation/wormhole-explorer/api/internal/pagination"
+	"github.com/wormhole-foundation/wormhole-explorer/api/types"
 	"github.com/wormhole-foundation/wormhole/sdk/vaa"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -1603,7 +1604,7 @@ type EnqueuedResponse struct {
 func (r *Repository) IsVaaEnqueued(
 	ctx context.Context,
 	chainID vaa.ChainID,
-	emitter vaa.Address,
+	emitter *types.Address,
 	sequence string,
 ) (bool, error) {
 
@@ -1636,7 +1637,7 @@ func (r *Repository) IsVaaEnqueued(
 	matchStage6 := bson.D{
 		{"$match", bson.D{
 			{"chainid", chainID},
-			{"emitters.emitteraddress", fmt.Sprintf("0x%s", emitter.String())},
+			{"emitters.emitteraddress", fmt.Sprintf("0x%s", emitter.ShortHex())},
 			{"emitters.enqueuedvaas.sequence", sequence},
 		}},
 	}

--- a/api/handlers/governor/service.go
+++ b/api/handlers/governor/service.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/wormhole-foundation/wormhole-explorer/api/internal/pagination"
 	"github.com/wormhole-foundation/wormhole-explorer/api/response"
+	"github.com/wormhole-foundation/wormhole-explorer/api/types"
 	"github.com/wormhole-foundation/wormhole/sdk/vaa"
 	"go.uber.org/zap"
 )
@@ -62,9 +63,16 @@ func (s *Service) FindGovernorStatus(ctx context.Context, p *pagination.Paginati
 }
 
 // FindGovernorStatusByGuardianAddress get a governor status by guardianAddress.
-func (s *Service) FindGovernorStatusByGuardianAddress(ctx context.Context, guardianAddress string, p *pagination.Pagination) (*response.Response[*GovStatus], error) {
+func (s *Service) FindGovernorStatusByGuardianAddress(
+	ctx context.Context,
+	guardianAddress string,
+	p *pagination.Pagination,
+) (*response.Response[*GovStatus], error) {
+
 	query := QueryGovernor().SetID(guardianAddress).SetPagination(p)
+
 	govStatus, err := s.repo.FindOneGovernorStatus(ctx, query)
+
 	res := response.Response[*GovStatus]{Data: govStatus}
 	return &res, err
 }
@@ -182,7 +190,7 @@ func (s *Service) GetEnqueuedVaas(ctx context.Context) ([]*EnqueuedVaaItem, erro
 
 // IsVaaEnqueued check vaa is enqueued.
 // Guardian api migration.
-func (s *Service) IsVaaEnqueued(ctx context.Context, chainID vaa.ChainID, emitter vaa.Address, seq string) (bool, error) {
+func (s *Service) IsVaaEnqueued(ctx context.Context, chainID vaa.ChainID, emitter *types.Address, seq string) (bool, error) {
 	isEnqueued, err := s.repo.IsVaaEnqueued(ctx, chainID, emitter, seq)
 	return isEnqueued, err
 }

--- a/api/handlers/observations/service.go
+++ b/api/handlers/observations/service.go
@@ -5,6 +5,7 @@ import (
 	"context"
 
 	"github.com/wormhole-foundation/wormhole-explorer/api/internal/pagination"
+	"github.com/wormhole-foundation/wormhole-explorer/api/types"
 	"github.com/wormhole-foundation/wormhole/sdk/vaa"
 	"go.uber.org/zap"
 )
@@ -32,19 +33,55 @@ func (s *Service) FindByChain(ctx context.Context, chain vaa.ChainID, p *paginat
 }
 
 // FindByEmitter get all the observations by chainID and emitter address.
-func (s *Service) FindByEmitter(ctx context.Context, chain vaa.ChainID, emitter *vaa.Address, p *pagination.Pagination) ([]*ObservationDoc, error) {
-	query := Query().SetChain(chain).SetEmitter(emitter.String()).SetPagination(p)
+func (s *Service) FindByEmitter(
+	ctx context.Context,
+	chain vaa.ChainID,
+	emitter *types.Address,
+	p *pagination.Pagination,
+) ([]*ObservationDoc, error) {
+
+	query := Query().
+		SetChain(chain).
+		SetEmitter(emitter.ShortHex()).
+		SetPagination(p)
+
 	return s.repo.Find(ctx, query)
 }
 
 // FindByVAA get all the observations for a VAA (chainID, emitter addrress and sequence number).
-func (s *Service) FindByVAA(ctx context.Context, chain vaa.ChainID, emitter *vaa.Address, seq string, p *pagination.Pagination) ([]*ObservationDoc, error) {
-	query := Query().SetChain(chain).SetEmitter(emitter.String()).SetSequence(seq).SetPagination(p)
+func (s *Service) FindByVAA(
+	ctx context.Context,
+	chain vaa.ChainID,
+	emitter *types.Address,
+	seq string,
+	p *pagination.Pagination,
+) ([]*ObservationDoc, error) {
+
+	query := Query().
+		SetChain(chain).
+		SetEmitter(emitter.ShortHex()).
+		SetSequence(seq).
+		SetPagination(p)
+
 	return s.repo.Find(ctx, query)
 }
 
 // FindOne get a observation by chainID, emitter address, sequence, signer address and hash.
-func (s *Service) FindOne(ctx context.Context, chainID vaa.ChainID, emitterAddr *vaa.Address, seq string, signerAddr *vaa.Address, hash []byte) (*ObservationDoc, error) {
-	query := Query().SetChain(chainID).SetEmitter(emitterAddr.String()).SetSequence(seq).SetGuardianAddr(signerAddr.String()).SetHash(hash)
+func (s *Service) FindOne(
+	ctx context.Context,
+	chainID vaa.ChainID,
+	emitterAddr *types.Address,
+	seq string,
+	signerAddr *vaa.Address,
+	hash []byte,
+) (*ObservationDoc, error) {
+
+	query := Query().
+		SetChain(chainID).
+		SetEmitter(emitterAddr.ShortHex()).
+		SetSequence(seq).
+		SetGuardianAddr(signerAddr.String()).
+		SetHash(hash)
+
 	return s.repo.FindOne(ctx, query)
 }

--- a/api/routes/guardian/governor/controller.go
+++ b/api/routes/guardian/governor/controller.go
@@ -139,7 +139,7 @@ func (c *Controller) IsVaaEnqueued(ctx *fiber.Ctx) error {
 	if err != nil {
 		return err
 	}
-	isEnqueued, err := c.srv.IsVaaEnqueued(ctx.Context(), chainID, *emitter, strconv.FormatUint(seq, 10))
+	isEnqueued, err := c.srv.IsVaaEnqueued(ctx.Context(), chainID, emitter, strconv.FormatUint(seq, 10))
 	if err != nil {
 		return err
 	}

--- a/api/routes/guardian/vaa/controller.go
+++ b/api/routes/guardian/vaa/controller.go
@@ -50,7 +50,7 @@ func (c *Controller) FindSignedVAAByID(ctx *fiber.Ctx) error {
 	vaa, err := c.srv.FindById(
 		ctx.Context(),
 		chainID,
-		*emitter,
+		emitter,
 		strconv.FormatUint(seq, 10),
 		false, /*includeParsedPayload*/
 	)

--- a/api/routes/wormscan/governor/controller.go
+++ b/api/routes/wormscan/governor/controller.go
@@ -65,7 +65,7 @@ func (c *Controller) FindGovernorConfigurationByGuardianAddress(ctx *fiber.Ctx) 
 	}
 
 	// query the database
-	govConfigs, err := c.srv.FindGovernorConfigByGuardianAddress(ctx.Context(), guardianAddress)
+	govConfigs, err := c.srv.FindGovernorConfigByGuardianAddress(ctx.Context(), guardianAddress.ShortHex())
 	if err != nil {
 		return err
 	} else if len(govConfigs) == 0 {
@@ -127,7 +127,7 @@ func (c *Controller) FindGovernorStatusByGuardianAddress(ctx *fiber.Ctx) error {
 		return err
 	}
 
-	govStatus, err := c.srv.FindGovernorStatusByGuardianAddress(ctx.Context(), guardianAddress, p)
+	govStatus, err := c.srv.FindGovernorStatusByGuardianAddress(ctx.Context(), guardianAddress.ShortHex(), p)
 	if err != nil {
 		return err
 	}

--- a/api/routes/wormscan/vaa/controller.go
+++ b/api/routes/wormscan/vaa/controller.go
@@ -128,7 +128,7 @@ func (c *Controller) FindByEmitter(ctx *fiber.Ctx) error {
 		return err
 	}
 
-	vaas, err := c.srv.FindByEmitter(ctx.Context(), chainID, *emitter, p)
+	vaas, err := c.srv.FindByEmitter(ctx.Context(), chainID, emitter, p)
 	if err != nil {
 		return err
 	}
@@ -163,7 +163,7 @@ func (c *Controller) FindById(ctx *fiber.Ctx) error {
 	vaa, err := c.srv.FindById(
 		ctx.Context(),
 		chainID,
-		*emitter,
+		emitter,
 		strconv.FormatUint(seq, 10),
 		includeParsedPayload,
 	)

--- a/api/types/address.go
+++ b/api/types/address.go
@@ -1,0 +1,56 @@
+package types
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/wormhole-foundation/wormhole/sdk/vaa"
+)
+
+type Address struct {
+	address vaa.Address
+}
+
+func BytesToAddress(b []byte) (*Address, error) {
+
+	var a Address
+
+	if len(b) != len(a.address) {
+		return nil, fmt.Errorf("expected byte slice to have len=%d, but got %d instead", len(a.address), len(b))
+	}
+
+	copy(a.address[:], b)
+
+	return &a, nil
+}
+
+// StringToAddress converts a hex-encoded address string into an *Address.
+func StringToAddress(s string) (*Address, error) {
+
+	a, err := vaa.StringToAddress(s)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Address{address: a}, nil
+}
+
+// Hex returns the full 32-byte address, encoded as hex.
+func (addr *Address) Hex() string {
+	return addr.address.String()
+}
+
+// ShortHex returns a hex-encoded address that is usually shorted than Hex().
+//
+// If the full address returned by Hex() is prefixed 12 bytes set to zero,
+// this function will trim those bytes.
+func (addr *Address) ShortHex() string {
+
+	full := addr.Hex()
+
+	if len(full) == 64 && strings.HasPrefix(full, "000000000000000000000000") {
+		return full[24:]
+	}
+
+	return full
+}

--- a/api/types/address_test.go
+++ b/api/types/address_test.go
@@ -1,0 +1,62 @@
+package types
+
+import "testing"
+
+// Test_Address_ShortString runs several test cases on the method `Address.ShortString()`.
+func Test_Address_ShortString(t *testing.T) {
+
+	testCases := []struct {
+		Input    string
+		Hex      string
+		ShortHex string
+	}{
+		{
+			Input:    "0x000000000000000000000000f890982f9310df57d00f659cf4fd87e65aded8d7",
+			Hex:      "000000000000000000000000f890982f9310df57d00f659cf4fd87e65aded8d7",
+			ShortHex: "f890982f9310df57d00f659cf4fd87e65aded8d7",
+		},
+		{
+			Input:    "000000000000000000000000f890982f9310df57d00f659cf4fd87e65aded8d7",
+			Hex:      "000000000000000000000000f890982f9310df57d00f659cf4fd87e65aded8d7",
+			ShortHex: "f890982f9310df57d00f659cf4fd87e65aded8d7",
+		},
+		{
+			Input:    "0xf890982f9310df57d00f659cf4fd87e65aded8d7",
+			Hex:      "000000000000000000000000f890982f9310df57d00f659cf4fd87e65aded8d7",
+			ShortHex: "f890982f9310df57d00f659cf4fd87e65aded8d7",
+		},
+		{
+			Input:    "f890982f9310df57d00f659cf4fd87e65aded8d7",
+			Hex:      "000000000000000000000000f890982f9310df57d00f659cf4fd87e65aded8d7",
+			ShortHex: "f890982f9310df57d00f659cf4fd87e65aded8d7",
+		},
+		{
+			Input:    "ec7372995d5cc8732397fb0ad35c0121e0eaa90d26f828a534cab54391b3a4f5",
+			Hex:      "ec7372995d5cc8732397fb0ad35c0121e0eaa90d26f828a534cab54391b3a4f5",
+			ShortHex: "ec7372995d5cc8732397fb0ad35c0121e0eaa90d26f828a534cab54391b3a4f5",
+		},
+		{
+			Input:    "0xec7372995d5cc8732397fb0ad35c0121e0eaa90d26f828a534cab54391b3a4f5",
+			Hex:      "ec7372995d5cc8732397fb0ad35c0121e0eaa90d26f828a534cab54391b3a4f5",
+			ShortHex: "ec7372995d5cc8732397fb0ad35c0121e0eaa90d26f828a534cab54391b3a4f5",
+		},
+	}
+
+	for i := range testCases {
+		tc := &testCases[i]
+
+		addr, err := StringToAddress(tc.Input)
+		if err != nil {
+			t.Fatalf("failed to parse address %s: %v", tc.Input, err)
+		}
+
+		if addr.Hex() != tc.Hex {
+			t.Fatalf("expected Address.Hex()=%s, but got %s", tc.Hex, addr.Hex())
+		}
+
+		if addr.ShortHex() != tc.ShortHex {
+			t.Fatalf("expected Address.ShortHex()=%s, but got %s", tc.ShortHex, addr.ShortHex())
+		}
+	}
+
+}


### PR DESCRIPTION
### Summary

Context: https://github.com/wormhole-foundation/wormhole-explorer/issues/154

This PR modifies all endpoints that receive an emitter/guardian address to accept a wider range of formats.
After this pull request, all of these are equivalent:
* `0x000000000000000000000000f890982f9310df57d00f659cf4fd87e65aded8d7`
* `000000000000000000000000f890982f9310df57d00f659cf4fd87e65aded8d7`
* `0xf890982f9310df57d00f659cf4fd87e65aded8d7`
* `f890982f9310df57d00f659cf4fd87e65aded8d7`

### Testing plan
* Added unit tests for the parsing code.
* Tested manually a few of the affected endpoints.