### PR TITLE
[API] Fix governor endpoints

### DIFF
--- a/api/handlers/governor/service.go
+++ b/api/handlers/governor/service.go
@@ -27,7 +27,7 @@ func (s *Service) FindGovernorConfig(ctx context.Context, p *pagination.Paginati
 	if p == nil {
 		p = pagination.Default()
 	}
-	query := QueryGovernor().SetPagination(p)
+	query := NewGovernorQuery().SetPagination(p)
 	govConfigs, err := s.repo.FindGovConfigurations(ctx, query)
 	res := response.Response[[]*GovConfig]{Data: govConfigs}
 	return &res, err
@@ -36,14 +36,14 @@ func (s *Service) FindGovernorConfig(ctx context.Context, p *pagination.Paginati
 // FindGovernorConfigByGuardianAddress get a governor configuration by guardianAddress.
 func (s *Service) FindGovernorConfigByGuardianAddress(
 	ctx context.Context,
-	guardianAddress string,
+	guardianAddress *types.Address,
 ) ([]*GovConfig, error) {
 
 	p := pagination.
 		Default().
 		SetLimit(1)
 
-	query := QueryGovernor().
+	query := NewGovernorQuery().
 		SetID(guardianAddress).
 		SetPagination(p)
 
@@ -56,7 +56,7 @@ func (s *Service) FindGovernorStatus(ctx context.Context, p *pagination.Paginati
 	if p == nil {
 		p = pagination.Default()
 	}
-	query := QueryGovernor().SetPagination(p)
+	query := NewGovernorQuery().SetPagination(p)
 	govStatus, err := s.repo.FindGovernorStatus(ctx, query)
 	res := response.Response[[]*GovStatus]{Data: govStatus}
 	return &res, err
@@ -65,11 +65,13 @@ func (s *Service) FindGovernorStatus(ctx context.Context, p *pagination.Paginati
 // FindGovernorStatusByGuardianAddress get a governor status by guardianAddress.
 func (s *Service) FindGovernorStatusByGuardianAddress(
 	ctx context.Context,
-	guardianAddress string,
+	guardianAddress *types.Address,
 	p *pagination.Pagination,
 ) (*response.Response[*GovStatus], error) {
 
-	query := QueryGovernor().SetID(guardianAddress).SetPagination(p)
+	query := NewGovernorQuery().
+		SetID(guardianAddress).
+		SetPagination(p)
 
 	govStatus, err := s.repo.FindOneGovernorStatus(ctx, query)
 
@@ -150,7 +152,7 @@ func (s *Service) GetGovernorLimit(ctx context.Context, p *pagination.Pagination
 	if p == nil {
 		p = pagination.Default()
 	}
-	query := QueryGovernor().SetPagination(p)
+	query := NewGovernorQuery().SetPagination(p)
 	governorLimit, err := s.repo.GetGovernorLimit(ctx, query)
 	res := response.Response[[]*GovernorLimit]{Data: governorLimit}
 	return &res, err

--- a/api/routes/wormscan/governor/controller.go
+++ b/api/routes/wormscan/governor/controller.go
@@ -65,7 +65,7 @@ func (c *Controller) FindGovernorConfigurationByGuardianAddress(ctx *fiber.Ctx) 
 	}
 
 	// query the database
-	govConfigs, err := c.srv.FindGovernorConfigByGuardianAddress(ctx.Context(), guardianAddress.Hex())
+	govConfigs, err := c.srv.FindGovernorConfigByGuardianAddress(ctx.Context(), guardianAddress)
 	if err != nil {
 		return err
 	} else if len(govConfigs) == 0 {
@@ -127,7 +127,7 @@ func (c *Controller) FindGovernorStatusByGuardianAddress(ctx *fiber.Ctx) error {
 		return err
 	}
 
-	govStatus, err := c.srv.FindGovernorStatusByGuardianAddress(ctx.Context(), guardianAddress.Hex(), p)
+	govStatus, err := c.srv.FindGovernorStatusByGuardianAddress(ctx.Context(), guardianAddress, p)
 	if err != nil {
 		return err
 	}

--- a/api/types/address.go
+++ b/api/types/address.go
@@ -44,6 +44,12 @@ func (addr *Address) Hex() string {
 //
 // If the full address returned by Hex() is prefixed 12 bytes set to zero,
 // this function will trim those bytes.
+//
+// The reason we need this function is that a few database collections
+// (governorConfig, governorStatus, heartbeats) store guardian addresses
+// as 40 hex digits instead of the full 64-digit hex representation.
+// When performing lookups over those collections, this function
+// can perform the conversion.
 func (addr *Address) ShortHex() string {
 
 	full := addr.Hex()
@@ -53,4 +59,13 @@ func (addr *Address) ShortHex() string {
 	}
 
 	return full
+}
+
+// Copy returns a deep copy of the address.
+func (addr *Address) Copy() *Address {
+
+	var tmp vaa.Address
+	copy(tmp[:], addr.address[:])
+
+	return &Address{address: tmp}
 }


### PR DESCRIPTION
### Summary

A few governor endpoints were handling addresses incorrectly, which resulted in errors:
* `GET /api/v1/governor/config/{governor_address}`
* `GET /api/v1/governor/status/{governor_address}`

Tracking issue: https://github.com/wormhole-foundation/wormhole-explorer/issues/201

This commit fixes the issue and adds doc comments to prevent the same caveat from happening again in the future.