### PR TITLE
[API] Fix serialization issue in HTTP responses

### DIFF
--- a/api/handlers/vaa/repository.go
+++ b/api/handlers/vaa/repository.go
@@ -73,6 +73,11 @@ func (r *Repository) Find(ctx context.Context, q *VaaQuery) ([]*VaaDoc, error) {
 		vaas[i].AppId = ""
 	}
 
+	// If no results were found, return an empty slice instead of nil.
+	if vaas == nil {
+		vaas = make([]*VaaDoc, 0)
+	}
+
 	return vaas, err
 }
 
@@ -206,6 +211,11 @@ func (r *Repository) FindVaasWithPayload(
 			zap.String("requestID", requestID),
 		)
 		return nil, errors.WithStack(err)
+	}
+
+	// If no results were found, return an empty slice instead of nil.
+	if vaasWithPayload == nil {
+		vaasWithPayload = make([]*VaaDoc, 0)
 	}
 
 	return vaasWithPayload, nil

--- a/api/routes/guardian/heartbeats/controller.go
+++ b/api/routes/guardian/heartbeats/controller.go
@@ -65,12 +65,20 @@ type HeartbeatNetworkResponse struct {
 // @Failure 500
 // @Router /v1/heartbeats [get]
 func (c *Controller) GetLastHeartbeats(ctx *fiber.Ctx) error {
+
 	// check guardianSet exists.
 	if len(c.gs.GstByIndex) == 0 {
-		return response.NewApiError(ctx, fiber.StatusServiceUnavailable, response.Unavailable,
-			"guardian set not fetched from chain yet", nil)
+		err := response.NewApiError(
+			ctx,
+			fiber.StatusServiceUnavailable,
+			response.Unavailable,
+			"guardian set not fetched from chain yet",
+			nil,
+		)
+		return err
 	}
-	// get lasted guardianSet.
+
+	// get the latest guardianSet.
 	guardianSet := c.gs.GetLatest()
 	guardianAddresses := guardianSet.KeysAsHexStrings()
 


### PR DESCRIPTION
### Summary

Several endpoints related to VAAs and observations returned `null` when no results were found.

This commit changes the behavior to return `[]` instead, which is more ergonomic for users.

Endpoints affected:
- `GET /api/v1/observations/:chain`
- `GET /api/v1/observations/:chain/:emitter`
- `GET /api/v1/observations/:chain/:emitter/:sequence`
- `GET /api/v1/observations/:chain/:emitter/:sequence/:signer/:hash`
- `GET /api/v1/vaas/{chain_id}`
- `GET /api/v1/vaas/{chain_id}/{emitter}`
- `GET /api/v1/vaas/{chain_id}/{emitter}/{seq}`