### PR TITLE
[API/ANALYTICS] Scorecards endpoint

### DIFF
--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -923,6 +923,26 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/scorecards": {
+            "get": {
+                "description": "Returns a list of KPIs for Wormhole.",
+                "tags": [
+                    "Wormscan"
+                ],
+                "operationId": "get-scorecards",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/transactions.ScorecardsResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            }
+        },
         "/api/v1/vaas/": {
             "get": {
                 "description": "Returns all VAAs. Output is paginated and can also be be sorted.",
@@ -2305,6 +2325,9 @@ const docTemplate = `{
                     "type": "number"
                 }
             }
+        },
+        "transactions.ScorecardsResponse": {
+            "type": "object"
         },
         "transactions.TransactionCountResult": {
             "type": "object",

--- a/api/docs/swagger.json
+++ b/api/docs/swagger.json
@@ -916,6 +916,26 @@
                 }
             }
         },
+        "/api/v1/scorecards": {
+            "get": {
+                "description": "Returns a list of KPIs for Wormhole.",
+                "tags": [
+                    "Wormscan"
+                ],
+                "operationId": "get-scorecards",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/transactions.ScorecardsResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            }
+        },
         "/api/v1/vaas/": {
             "get": {
                 "description": "Returns all VAAs. Output is paginated and can also be be sorted.",
@@ -2298,6 +2318,9 @@
                     "type": "number"
                 }
             }
+        },
+        "transactions.ScorecardsResponse": {
+            "type": "object"
         },
         "transactions.TransactionCountResult": {
             "type": "object",

--- a/api/docs/swagger.yaml
+++ b/api/docs/swagger.yaml
@@ -482,6 +482,8 @@ definitions:
       volume:
         type: number
     type: object
+  transactions.ScorecardsResponse:
+    type: object
   transactions.TransactionCountResult:
     properties:
       count:
@@ -1212,6 +1214,19 @@ paths:
               type: object
         "400":
           description: Bad Request
+        "500":
+          description: Internal Server Error
+      tags:
+      - Wormscan
+  /api/v1/scorecards:
+    get:
+      description: Returns a list of KPIs for Wormhole.
+      operationId: get-scorecards
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/transactions.ScorecardsResponse'
         "500":
           description: Internal Server Error
       tags:

--- a/api/handlers/transactions/model.go
+++ b/api/handlers/transactions/model.go
@@ -8,6 +8,9 @@ import (
 )
 
 type Scorecards struct {
+	// Number of VAAs emitted since the creation of the network (does not include Pyth messages)
+	TotalTxCount string
+
 	// Number of VAAs emitted in the last 24 hours (does not include Pyth messages).
 	TxCount24h string
 }

--- a/api/handlers/transactions/model.go
+++ b/api/handlers/transactions/model.go
@@ -7,6 +7,11 @@ import (
 	"github.com/wormhole-foundation/wormhole/sdk/vaa"
 )
 
+type Scorecards struct {
+	// Number of VAAs emitted in the last 24 hours (does not include Pyth messages).
+	TxCount24h string
+}
+
 type GlobalTransactionDoc struct {
 	ID            string         `bson:"_id" json:"id"`
 	OriginTx      *OriginTx      `bson:"originTx" json:"originTx"`

--- a/api/handlers/transactions/service.go
+++ b/api/handlers/transactions/service.go
@@ -24,6 +24,10 @@ func (s *Service) GetTransactionCount(ctx context.Context, q *TransactionCountQu
 	return s.repo.GetTransactionCount(ctx, q)
 }
 
+func (s *Service) GetScorecards(ctx context.Context) (*Scorecards, error) {
+	return s.repo.GetScorecards(ctx)
+}
+
 // GetChainActivity get chain activity.
 func (s *Service) GetChainActivity(ctx context.Context, q *ChainActivityQuery) ([]ChainActivityResult, error) {
 	return s.repo.FindChainActivity(ctx, q)

--- a/api/routes/wormscan/routes.go
+++ b/api/routes/wormscan/routes.go
@@ -63,9 +63,10 @@ func RegisterRoutes(
 	api.Get("/address/:id", addressCtrl.FindById)
 
 	// analytics
-	api.Get("/last-txs", transactionCtrl.GetLastTransactions)
-	api.Get("/x-chain-activity", transactionCtrl.GetChainActivity)
 	api.Get("/global-tx/:chain/:emitter/:sequence", transactionCtrl.FindGlobalTransactionByID)
+	api.Get("/last-txs", transactionCtrl.GetLastTransactions)
+	api.Get("/scorecards", transactionCtrl.GetScorecards)
+	api.Get("/x-chain-activity", transactionCtrl.GetChainActivity)
 
 	// vaas resource
 	vaas := api.Group("/vaas")

--- a/api/routes/wormscan/transactions/controller.go
+++ b/api/routes/wormscan/transactions/controller.go
@@ -75,7 +75,8 @@ func (c *Controller) GetScorecards(ctx *fiber.Ctx) error {
 
 	// Convert indicators to the response model
 	response := ScorecardsResponse{
-		TxCount24h: scorecards.TxCount24h,
+		TxCount24h:   scorecards.TxCount24h,
+		TotalTxCount: scorecards.TotalTxCount,
 	}
 
 	return ctx.JSON(response)

--- a/api/routes/wormscan/transactions/controller.go
+++ b/api/routes/wormscan/transactions/controller.go
@@ -58,6 +58,20 @@ func (c *Controller) GetLastTransactions(ctx *fiber.Ctx) error {
 	return ctx.JSON(lastTrx)
 }
 
+// GetScorecards godoc
+// @Description Returns a list of KPIs for Wormhole.
+// @Tags Wormscan
+// @ID get-scorecards
+// @Success 200 {object} ScorecardsResponse
+// @Failure 500
+// @Router /api/v1/scorecards [get]
+func (c *Controller) GetScorecards(ctx *fiber.Ctx) error {
+
+	response := ScorecardsResponse{}
+
+	return ctx.JSON(response)
+}
+
 // GetChainActivity godoc
 // @Description Returns a list of tx by source chain and destination chain.
 // @Tags Wormscan

--- a/api/routes/wormscan/transactions/controller.go
+++ b/api/routes/wormscan/transactions/controller.go
@@ -67,7 +67,16 @@ func (c *Controller) GetLastTransactions(ctx *fiber.Ctx) error {
 // @Router /api/v1/scorecards [get]
 func (c *Controller) GetScorecards(ctx *fiber.Ctx) error {
 
-	response := ScorecardsResponse{}
+	// Query indicators from the database
+	scorecards, err := c.srv.GetScorecards(ctx.Context())
+	if err != nil {
+		return err
+	}
+
+	// Convert indicators to the response model
+	response := ScorecardsResponse{
+		TxCount24h: scorecards.TxCount24h,
+	}
 
 	return ctx.JSON(response)
 }

--- a/api/routes/wormscan/transactions/response.go
+++ b/api/routes/wormscan/transactions/response.go
@@ -19,3 +19,23 @@ type Destination struct {
 type ChainActivity struct {
 	Txs []Tx `json:"txs"`
 }
+
+// ScorecardsResponse is the response model for the endpoint `GET /api/v1/scorecards`.
+type ScorecardsResponse struct {
+	//TODO: we don't have the data for these fields yet, uncomment as the data becomes available.
+
+	//TVL          string `json:"tvl"`
+
+	//TotalVolume  string `json:"total_volume"`
+
+	// Number of VAAs emitted since the creation of the network (does not include Pyth messages)
+	//TotalTxCount string `json:"total_tx_count"`
+
+	//Volume24h    string `json:"24h_volume"`
+
+	// Number of VAAs emitted in the last 24 hours (does not include Pyth messages).
+	//TxCount24h       string `json:"24h_tx_count"`
+
+	// Number of VAAs emitted in the last 24 hours (includes Pyth messages).
+	//Messages24h  string `json:"24h_messages"`
+}

--- a/api/routes/wormscan/transactions/response.go
+++ b/api/routes/wormscan/transactions/response.go
@@ -29,7 +29,7 @@ type ScorecardsResponse struct {
 	//TotalVolume  string `json:"total_volume"`
 
 	// Number of VAAs emitted since the creation of the network (does not include Pyth messages)
-	//TotalTxCount string `json:"total_tx_count"`
+	TotalTxCount string `json:"total_tx_count,omitempty"`
 
 	//Volume24h    string `json:"24h_volume"`
 

--- a/api/routes/wormscan/transactions/response.go
+++ b/api/routes/wormscan/transactions/response.go
@@ -34,7 +34,7 @@ type ScorecardsResponse struct {
 	//Volume24h    string `json:"24h_volume"`
 
 	// Number of VAAs emitted in the last 24 hours (does not include Pyth messages).
-	//TxCount24h       string `json:"24h_tx_count"`
+	TxCount24h string `json:"24h_tx_count"`
 
 	// Number of VAAs emitted in the last 24 hours (includes Pyth messages).
 	//Messages24h  string `json:"24h_messages"`


### PR DESCRIPTION
### Summary

This pull request adds the `GET /api/v1/scorecards` endpoint, which is required by the wormscan frontend.

Most of the fields that this endpoint should return are being omitted because the data is not currently available on the backend. Those fields will be added iteratively as the data becomes available.

The current format of the response is:
```json
{
  "total_tx_count": "1300200",
  "24h_tx_count": "4200"
}
```

Tracking issue: https://github.com/wormhole-foundation/wormhole-explorer/issues/221

## Deployment details

In order to populate the `"total_tx_count"` metric, a task is needed in influxdb:

```
$ cat total-vaa-count.flux 
option task = {
	name: "Total number of emitted VAAs",
	every: 1m
}

from(bucket: "wormhole-explorer")
  |> range(start: 2018-01-01T00:00:00Z)
  |> filter(fn: (r) => r._measurement == "vaa_count")
  |> group(columns: ["_measurement"])
  |> set(key: "_measurement", value: "total_vaa_count")
  |> count()
  |> map(fn: (r) => ({r with _time: now()}))
  |> map(fn: (r) => ({r with _field: "total_vaa_count"}))
  |> to(bucket: "wormhole-explorer", org: "xlabs")

```