### PR TITLE
[API] Add 24h messages to `GET /api/v1/scorecards`

### DIFF
--- a/analytic/cmd/main.go
+++ b/analytic/cmd/main.go
@@ -17,7 +17,6 @@ import (
 	"github.com/wormhole-foundation/wormhole-explorer/analytic/metric"
 	"github.com/wormhole-foundation/wormhole-explorer/analytic/queue"
 	sqs_client "github.com/wormhole-foundation/wormhole-explorer/common/client/sqs"
-	domain "github.com/wormhole-foundation/wormhole-explorer/common/domain"
 	health "github.com/wormhole-foundation/wormhole-explorer/common/health"
 	"github.com/wormhole-foundation/wormhole-explorer/common/logger"
 	"go.uber.org/zap"
@@ -98,8 +97,7 @@ func newVAAConsume(appCtx context.Context, config *config.Configuration, logger 
 		logger.Fatal("failed to create sqs consumer", zap.Error(err))
 	}
 
-	filterConsumeFunc := newFilterFunc(config)
-	vaaQueue := queue.NewVAASQS(sqsConsumer, filterConsumeFunc, logger)
+	vaaQueue := queue.NewVAASQS(sqsConsumer, queue.NonFilter, logger)
 	return vaaQueue.Consume
 }
 
@@ -135,13 +133,6 @@ func newAwsConfig(appCtx context.Context, cfg *config.Configuration) (aws.Config
 		awsconfig.WithCredentialsProvider(credentials),
 	)
 	return awsCfg, err
-}
-
-func newFilterFunc(cfg *config.Configuration) queue.FilterConsumeFunc {
-	if cfg.P2pNetwork == domain.P2pMainNet {
-		return queue.PythFilter
-	}
-	return queue.NonFilter
 }
 
 func newInfluxClient(url, token string) influxdb2.Client {

--- a/analytic/metric/metric.go
+++ b/analytic/metric/metric.go
@@ -8,6 +8,7 @@ import (
 	influxdb2 "github.com/influxdata/influxdb-client-go/v2"
 	"github.com/influxdata/influxdb-client-go/v2/api"
 	"github.com/wormhole-foundation/wormhole/sdk/vaa"
+	sdk "github.com/wormhole-foundation/wormhole/sdk/vaa"
 	"go.uber.org/zap"
 )
 
@@ -37,24 +38,50 @@ func (m *Metric) Close() {
 // vaaCountMeasurement handle the push of metric point for measurement vaa_count.
 func (m *Metric) vaaCountMeasurement(ctx context.Context, vaa *vaa.VAA) error {
 
-	measurement := "vaa_count"
+	// Create a measurement for all messages (including Pyth)
+	{
+		measurement := "vaa_count_including_pyth"
 
-	// Create a new point for the `vaa_count` measurement.
-	point := influxdb2.
-		NewPointWithMeasurement(measurement).
-		AddTag("chain_id", strconv.Itoa(int(vaa.EmitterChain))).
-		AddField("count", 1).
-		SetTime(vaa.Timestamp.Add(time.Nanosecond * time.Duration(vaa.Sequence)))
+		// Create a new point for the `vaa_count` measurement.
+		point := influxdb2.
+			NewPointWithMeasurement(measurement).
+			AddTag("chain_id", strconv.Itoa(int(vaa.EmitterChain))).
+			AddField("count", 1).
+			SetTime(vaa.Timestamp.Add(time.Nanosecond * time.Duration(vaa.Sequence)))
 
-	// Write the point to influx.
-	err := m.writeApi.WritePoint(ctx, point)
-	if err != nil {
-		m.logger.Error("failed to write metric",
-			zap.String("measurement", measurement),
-			zap.Uint16("chain_id", uint16(vaa.EmitterChain)),
-			zap.Error(err),
-		)
-		return err
+		// Write the point to influx.
+		err := m.writeApi.WritePoint(ctx, point)
+		if err != nil {
+			m.logger.Error("failed to write metric",
+				zap.String("measurement", measurement),
+				zap.Uint16("chain_id", uint16(vaa.EmitterChain)),
+				zap.Error(err),
+			)
+			return err
+		}
+	}
+
+	// Create a measurement for non-pyth messages only
+	if vaa.EmitterChain != sdk.ChainIDPythNet {
+		measurement := "vaa_count"
+
+		// Create a new point for the `vaa_count` measurement.
+		point := influxdb2.
+			NewPointWithMeasurement(measurement).
+			AddTag("chain_id", strconv.Itoa(int(vaa.EmitterChain))).
+			AddField("count", 1).
+			SetTime(vaa.Timestamp.Add(time.Nanosecond * time.Duration(vaa.Sequence)))
+
+		// Write the point to influx.
+		err := m.writeApi.WritePoint(ctx, point)
+		if err != nil {
+			m.logger.Error("failed to write metric",
+				zap.String("measurement", measurement),
+				zap.Uint16("chain_id", uint16(vaa.EmitterChain)),
+				zap.Error(err),
+			)
+			return err
+		}
 	}
 
 	return nil

--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -2327,7 +2327,21 @@ const docTemplate = `{
             }
         },
         "transactions.ScorecardsResponse": {
-            "type": "object"
+            "type": "object",
+            "properties": {
+                "24h_messages": {
+                    "description": "Number of VAAs emitted in the last 24 hours (includes Pyth messages).",
+                    "type": "string"
+                },
+                "24h_tx_count": {
+                    "description": "Number of VAAs emitted in the last 24 hours (does not include Pyth messages).",
+                    "type": "string"
+                },
+                "total_tx_count": {
+                    "description": "Number of VAAs emitted since the creation of the network (does not include Pyth messages)",
+                    "type": "string"
+                }
+            }
         },
         "transactions.TransactionCountResult": {
             "type": "object",
@@ -2391,7 +2405,8 @@ const docTemplate = `{
                 28,
                 29,
                 30,
-                3104
+                3104,
+                10002
             ],
             "x-enum-varnames": [
                 "ChainIDUnset",
@@ -2422,7 +2437,8 @@ const docTemplate = `{
                 "ChainIDXpla",
                 "ChainIDBtc",
                 "ChainIDBase",
-                "ChainIDWormchain"
+                "ChainIDWormchain",
+                "ChainIDSepolia"
             ]
         },
         "vaa.VaaDoc": {

--- a/api/docs/swagger.json
+++ b/api/docs/swagger.json
@@ -2320,7 +2320,21 @@
             }
         },
         "transactions.ScorecardsResponse": {
-            "type": "object"
+            "type": "object",
+            "properties": {
+                "24h_messages": {
+                    "description": "Number of VAAs emitted in the last 24 hours (includes Pyth messages).",
+                    "type": "string"
+                },
+                "24h_tx_count": {
+                    "description": "Number of VAAs emitted in the last 24 hours (does not include Pyth messages).",
+                    "type": "string"
+                },
+                "total_tx_count": {
+                    "description": "Number of VAAs emitted since the creation of the network (does not include Pyth messages)",
+                    "type": "string"
+                }
+            }
         },
         "transactions.TransactionCountResult": {
             "type": "object",
@@ -2384,7 +2398,8 @@
                 28,
                 29,
                 30,
-                3104
+                3104,
+                10002
             ],
             "x-enum-varnames": [
                 "ChainIDUnset",
@@ -2415,7 +2430,8 @@
                 "ChainIDXpla",
                 "ChainIDBtc",
                 "ChainIDBase",
-                "ChainIDWormchain"
+                "ChainIDWormchain",
+                "ChainIDSepolia"
             ]
         },
         "vaa.VaaDoc": {

--- a/api/docs/swagger.yaml
+++ b/api/docs/swagger.yaml
@@ -483,6 +483,18 @@ definitions:
         type: number
     type: object
   transactions.ScorecardsResponse:
+    properties:
+      24h_messages:
+        description: Number of VAAs emitted in the last 24 hours (includes Pyth messages).
+        type: string
+      24h_tx_count:
+        description: Number of VAAs emitted in the last 24 hours (does not include
+          Pyth messages).
+        type: string
+      total_tx_count:
+        description: Number of VAAs emitted since the creation of the network (does
+          not include Pyth messages)
+        type: string
     type: object
   transactions.TransactionCountResult:
     properties:
@@ -535,6 +547,7 @@ definitions:
     - 29
     - 30
     - 3104
+    - 10002
     type: integer
     x-enum-varnames:
     - ChainIDUnset
@@ -566,6 +579,7 @@ definitions:
     - ChainIDBtc
     - ChainIDBase
     - ChainIDWormchain
+    - ChainIDSepolia
   vaa.VaaDoc:
     properties:
       appId:

--- a/api/handlers/transactions/model.go
+++ b/api/handlers/transactions/model.go
@@ -13,6 +13,9 @@ type Scorecards struct {
 
 	// Number of VAAs emitted in the last 24 hours (does not include Pyth messages).
 	TxCount24h string
+
+	// Number of VAAs emitted in the last 24 hours (includes Pyth messages).
+	Messages24h string
 }
 
 type GlobalTransactionDoc struct {

--- a/api/routes/wormscan/transactions/controller.go
+++ b/api/routes/wormscan/transactions/controller.go
@@ -77,6 +77,7 @@ func (c *Controller) GetScorecards(ctx *fiber.Ctx) error {
 	response := ScorecardsResponse{
 		TxCount24h:   scorecards.TxCount24h,
 		TotalTxCount: scorecards.TotalTxCount,
+		Messages24h:  scorecards.Messages24h,
 	}
 
 	return ctx.JSON(response)

--- a/api/routes/wormscan/transactions/response.go
+++ b/api/routes/wormscan/transactions/response.go
@@ -37,5 +37,5 @@ type ScorecardsResponse struct {
 	TxCount24h string `json:"24h_tx_count"`
 
 	// Number of VAAs emitted in the last 24 hours (includes Pyth messages).
-	//Messages24h  string `json:"24h_messages"`
+	Messages24h string `json:"24h_messages"`
 }


### PR DESCRIPTION
### Summary

This pull request adds the `24h_messages` field to the response in `GET /api/v1/scorecards`. This field indicates the total number of VAAs emitted in the last 24 hours, including messages from PythNet.

Also, the analytics component has been updated to store information about PythNet VAAs.

**Status:** this is currently blocked, because we don't have a bucket with a short retention policy for PythNet messages.