### PR TITLE
Sort the output of `GET /api/v1/vaas` by timestamp

### DIFF
--- a/api/handlers/governor/repository.go
+++ b/api/handlers/governor/repository.go
@@ -142,7 +142,8 @@ func (r *Repository) FindGovernorStatus(
 	q *GovernorQuery,
 ) ([]*GovStatus, error) {
 
-	sort := bson.D{{Key: q.SortBy, Value: q.GetSortInt()}}
+	// Sort guardians by ascending ID to guarantee deterministic output.
+	sort := bson.D{{Key: "_id", Value: 1}}
 
 	projection := bson.D{
 		{Key: "createdAt", Value: 1},

--- a/api/handlers/observations/repository.go
+++ b/api/handlers/observations/repository.go
@@ -36,7 +36,9 @@ func NewRepository(db *mongo.Database, logger *zap.Logger) *Repository {
 // The input parameter [q *ObservationQuery] define the filters to apply in the query.
 func (r *Repository) Find(ctx context.Context, q *ObservationQuery) ([]*ObservationDoc, error) {
 
-	sort := bson.D{{q.SortBy, q.GetSortInt()}}
+	// Sort observations by ascending ID to provide deterministic output.
+	sort := bson.D{{"_id", 1}}
+
 	cur, err := r.collections.observations.Find(ctx, q.toBSON(), options.Find().SetLimit(q.Limit).SetSkip(q.Skip).SetSort(sort))
 	if err != nil {
 		requestID := fmt.Sprintf("%v", ctx.Value("requestid"))

--- a/api/handlers/vaa/repository.go
+++ b/api/handlers/vaa/repository.go
@@ -108,7 +108,7 @@ func (r *Repository) FindVaas(
 	{
 		// specify sorting criteria
 		pipeline = append(pipeline, bson.D{
-			{"$sort", bson.D{bson.E{q.SortBy, q.GetSortInt()}}},
+			{"$sort", bson.D{q.getSortPredicate()}},
 		})
 
 		// filter by _id
@@ -349,9 +349,13 @@ func (q *VaaQuery) toBSON() *bson.D {
 	return &r
 }
 
+func (q *VaaQuery) getSortPredicate() bson.E {
+	return bson.E{"timestamp", q.GetSortInt()}
+}
+
 func (q *VaaQuery) findOptions() *options.FindOptions {
 
-	sort := bson.D{{q.SortBy, q.GetSortInt()}}
+	sort := bson.D{q.getSortPredicate()}
 
 	return options.
 		Find().

--- a/api/internal/pagination/pagination.go
+++ b/api/internal/pagination/pagination.go
@@ -5,7 +5,6 @@ type Pagination struct {
 	Skip      int64
 	Limit     int64
 	SortOrder string
-	SortBy    string
 }
 
 // Default returns a `*Pagination` with default values.
@@ -15,7 +14,6 @@ func Default() *Pagination {
 		Skip:      0,
 		Limit:     50,
 		SortOrder: "DESC",
-		SortBy:    "indexedAt",
 	}
 
 	return p
@@ -33,11 +31,6 @@ func (p *Pagination) SetLimit(limit int64) *Pagination {
 
 func (p *Pagination) SetSortOrder(sortOrder string) *Pagination {
 	p.SortOrder = sortOrder
-	return p
-}
-
-func (p *Pagination) SetSortBy(sortBy string) *Pagination {
-	p.SortBy = sortBy
 	return p
 }
 


### PR DESCRIPTION
### Summary

The output of `GET /api/v1/vaas` was not being correctly sorted. This pull request changes the behavior so that the output will be sorted by the `timestamp` field.

Additionally, duplicated code was removed in the VAA code that handles queries.

Also, there was an unused query parameter `sortBy` which was being exposed but not used. Hence it was removed.

Tracking issue: https://github.com/wormhole-foundation/wormhole-explorer/issues/233