### PR TITLE
Fix inaccurate volume in `GET /api/v1/scorecards`

### DIFF
--- a/api/handlers/transactions/repository.go
+++ b/api/handlers/transactions/repository.go
@@ -50,7 +50,15 @@ from(bucket: "%s")
   |> range(start: -24h)
   |> filter(fn: (r) => r._measurement == "vaa_volume")
   |> filter(fn:(r) => r._field == "volume")
-  |> drop(columns: ["_measurement", "app_id", "destination_address", "destination_chain", "token_address", "token_chain"])
+  |> drop(columns: [
+		"_measurement",
+		"app_id",
+		"destination_address",
+		"destination_chain",
+		"emitter_chain",
+		"token_address",
+		"token_chain"
+	])
   |> sum(column: "_value")
 `
 

--- a/api/routes/wormscan/transactions/controller.go
+++ b/api/routes/wormscan/transactions/controller.go
@@ -150,22 +150,21 @@ func (c *Controller) GetTopAssets(ctx *fiber.Ctx) error {
 	}
 	for i := range assetDTOs {
 
-		// Look up the token symbol
-		tokenMeta, ok := domain.GetTokenByAddress(assetDTOs[i].TokenChain, assetDTOs[i].TokenAddress)
-		if !ok {
-			c.logger.Warn("failed to obtain token metadata in top volume chart",
-				zap.String("token_chain", assetDTOs[i].TokenChain.String()),
-				zap.String("token_address", assetDTOs[i].TokenAddress),
-			)
-			continue
+		asset := AssetWithVolume{
+			TokenChain:   assetDTOs[i].EmitterChain,
+			TokenAddress: assetDTOs[i].TokenAddress,
+			Volume:       assetDTOs[i].Volume,
 		}
 
-		// Populate the response struct
-		asset := AssetWithVolume{
-			EmitterChain: assetDTOs[i].EmitterChain,
-			Volume:       assetDTOs[i].Volume,
-			Symbol:       tokenMeta.Symbol,
+		// Look up the token symbol
+		//
+		// The explorer UI doesn't use this field, it uses the pair (tokenChain, tokenAddress) instead.
+		// The symbol field is not strictly necessary, but it's nice to have it in the response.
+		tokenMeta, ok := domain.GetTokenByAddress(assetDTOs[i].TokenChain, assetDTOs[i].TokenAddress)
+		if ok {
+			asset.Symbol = tokenMeta.Symbol
 		}
+
 		response.Assets = append(response.Assets, asset)
 	}
 

--- a/api/routes/wormscan/transactions/controller.go
+++ b/api/routes/wormscan/transactions/controller.go
@@ -151,7 +151,8 @@ func (c *Controller) GetTopAssets(ctx *fiber.Ctx) error {
 	for i := range assetDTOs {
 
 		asset := AssetWithVolume{
-			TokenChain:   assetDTOs[i].EmitterChain,
+			EmitterChain: assetDTOs[i].EmitterChain,
+			TokenChain:   assetDTOs[i].TokenChain,
 			TokenAddress: assetDTOs[i].TokenAddress,
 			Volume:       assetDTOs[i].Volume,
 		}

--- a/api/routes/wormscan/transactions/response.go
+++ b/api/routes/wormscan/transactions/response.go
@@ -50,8 +50,9 @@ type TopAssetsResponse struct {
 }
 
 type AssetWithVolume struct {
-	EmitterChain sdk.ChainID `json:"emitterChain"`
-	Symbol       string      `json:"symbol"`
+	Symbol       string      `json:"symbol,omitempty"`
+	TokenChain   sdk.ChainID `json:"tokenChain"`
+	TokenAddress string      `json:"tokenAddress"`
 	Volume       string      `json:"volume"`
 }
 

--- a/api/routes/wormscan/transactions/response.go
+++ b/api/routes/wormscan/transactions/response.go
@@ -50,6 +50,7 @@ type TopAssetsResponse struct {
 }
 
 type AssetWithVolume struct {
+	EmitterChain sdk.ChainID `json:"emitterChain"`
 	Symbol       string      `json:"symbol,omitempty"`
 	TokenChain   sdk.ChainID `json:"tokenChain"`
 	TokenAddress string      `json:"tokenAddress"`


### PR DESCRIPTION
The endpoint `GET /api/v1/scorecards` was returning an inaccurate number for the volume metric. This pull request fixes the issue.

Additionally, the response model of `GET /api/v1/top-assets-by-volume` has been changed as specified by @raop155:
```
{
  "assets": [
    {
      "symbol": "USDCet",
      "tokenChain": 1,
      "tokenAddress": "000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
      "volume": "475173.83806883"
    }
  ]
}

```