### PR TITLE
[API] Fix sorting order in observation endpoints

### DIFF
--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -640,7 +640,7 @@ const docTemplate = `{
         },
         "/api/v1/observations": {
             "get": {
-                "description": "Returns all observations, sorted by descending timestamp.",
+                "description": "Returns all observations, sorted in descending timestamp order.",
                 "tags": [
                     "Wormscan"
                 ],
@@ -690,7 +690,7 @@ const docTemplate = `{
         },
         "/api/v1/observations/:chain": {
             "get": {
-                "description": "Returns all observations for a given blockchain, sorted by descending timestamp.",
+                "description": "Returns all observations for a given blockchain, sorted in descending timestamp order.",
                 "tags": [
                     "Wormscan"
                 ],
@@ -740,7 +740,7 @@ const docTemplate = `{
         },
         "/api/v1/observations/:chain/:emitter": {
             "get": {
-                "description": "Returns all observations for a specific emitter address, sorted by descending timestamp.",
+                "description": "Returns all observations for a specific emitter address, sorted in descending timestamp order.",
                 "tags": [
                     "Wormscan"
                 ],

--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -640,7 +640,7 @@ const docTemplate = `{
         },
         "/api/v1/observations": {
             "get": {
-                "description": "Returns all observations.",
+                "description": "Returns all observations, sorted by descending timestamp.",
                 "tags": [
                     "Wormscan"
                 ],
@@ -690,7 +690,7 @@ const docTemplate = `{
         },
         "/api/v1/observations/:chain": {
             "get": {
-                "description": "Returns all observations for a given blockchain.",
+                "description": "Returns all observations for a given blockchain, sorted by descending timestamp.",
                 "tags": [
                     "Wormscan"
                 ],
@@ -740,7 +740,7 @@ const docTemplate = `{
         },
         "/api/v1/observations/:chain/:emitter": {
             "get": {
-                "description": "Returns all observations for a specific emitter address.",
+                "description": "Returns all observations for a specific emitter address, sorted by descending timestamp.",
                 "tags": [
                     "Wormscan"
                 ],

--- a/api/docs/swagger.json
+++ b/api/docs/swagger.json
@@ -633,7 +633,7 @@
         },
         "/api/v1/observations": {
             "get": {
-                "description": "Returns all observations.",
+                "description": "Returns all observations, sorted by descending timestamp.",
                 "tags": [
                     "Wormscan"
                 ],
@@ -683,7 +683,7 @@
         },
         "/api/v1/observations/:chain": {
             "get": {
-                "description": "Returns all observations for a given blockchain.",
+                "description": "Returns all observations for a given blockchain, sorted by descending timestamp.",
                 "tags": [
                     "Wormscan"
                 ],
@@ -733,7 +733,7 @@
         },
         "/api/v1/observations/:chain/:emitter": {
             "get": {
-                "description": "Returns all observations for a specific emitter address.",
+                "description": "Returns all observations for a specific emitter address, sorted by descending timestamp.",
                 "tags": [
                     "Wormscan"
                 ],

--- a/api/docs/swagger.json
+++ b/api/docs/swagger.json
@@ -633,7 +633,7 @@
         },
         "/api/v1/observations": {
             "get": {
-                "description": "Returns all observations, sorted by descending timestamp.",
+                "description": "Returns all observations, sorted in descending timestamp order.",
                 "tags": [
                     "Wormscan"
                 ],
@@ -683,7 +683,7 @@
         },
         "/api/v1/observations/:chain": {
             "get": {
-                "description": "Returns all observations for a given blockchain, sorted by descending timestamp.",
+                "description": "Returns all observations for a given blockchain, sorted in descending timestamp order.",
                 "tags": [
                     "Wormscan"
                 ],
@@ -733,7 +733,7 @@
         },
         "/api/v1/observations/:chain/:emitter": {
             "get": {
-                "description": "Returns all observations for a specific emitter address, sorted by descending timestamp.",
+                "description": "Returns all observations for a specific emitter address, sorted in descending timestamp order.",
                 "tags": [
                     "Wormscan"
                 ],

--- a/api/docs/swagger.yaml
+++ b/api/docs/swagger.yaml
@@ -1093,7 +1093,7 @@ paths:
       - Wormscan
   /api/v1/observations:
     get:
-      description: Returns all observations.
+      description: Returns all observations, sorted by descending timestamp.
       operationId: find-observations
       parameters:
       - description: Page number.
@@ -1126,7 +1126,8 @@ paths:
       - Wormscan
   /api/v1/observations/:chain:
     get:
-      description: Returns all observations for a given blockchain.
+      description: Returns all observations for a given blockchain, sorted by descending
+        timestamp.
       operationId: find-observations-by-chain
       parameters:
       - description: Page number.
@@ -1159,7 +1160,8 @@ paths:
       - Wormscan
   /api/v1/observations/:chain/:emitter:
     get:
-      description: Returns all observations for a specific emitter address.
+      description: Returns all observations for a specific emitter address, sorted
+        by descending timestamp.
       operationId: find-observations-by-emitter
       parameters:
       - description: Page number.

--- a/api/docs/swagger.yaml
+++ b/api/docs/swagger.yaml
@@ -1093,7 +1093,7 @@ paths:
       - Wormscan
   /api/v1/observations:
     get:
-      description: Returns all observations, sorted by descending timestamp.
+      description: Returns all observations, sorted in descending timestamp order.
       operationId: find-observations
       parameters:
       - description: Page number.
@@ -1126,8 +1126,8 @@ paths:
       - Wormscan
   /api/v1/observations/:chain:
     get:
-      description: Returns all observations for a given blockchain, sorted by descending
-        timestamp.
+      description: Returns all observations for a given blockchain, sorted in descending
+        timestamp order.
       operationId: find-observations-by-chain
       parameters:
       - description: Page number.
@@ -1161,7 +1161,7 @@ paths:
   /api/v1/observations/:chain/:emitter:
     get:
       description: Returns all observations for a specific emitter address, sorted
-        by descending timestamp.
+        in descending timestamp order.
       operationId: find-observations-by-emitter
       parameters:
       - description: Page number.

--- a/api/handlers/observations/repository.go
+++ b/api/handlers/observations/repository.go
@@ -36,8 +36,8 @@ func NewRepository(db *mongo.Database, logger *zap.Logger) *Repository {
 // The input parameter [q *ObservationQuery] define the filters to apply in the query.
 func (r *Repository) Find(ctx context.Context, q *ObservationQuery) ([]*ObservationDoc, error) {
 
-	// Sort observations by ascending ID to provide deterministic output.
-	sort := bson.D{{"_id", 1}}
+	// Sort observations by descending timestamp
+	sort := bson.D{{"indexedAt", -1}}
 
 	cur, err := r.collections.observations.Find(ctx, q.toBSON(), options.Find().SetLimit(q.Limit).SetSkip(q.Skip).SetSort(sort))
 	if err != nil {

--- a/api/handlers/observations/repository.go
+++ b/api/handlers/observations/repository.go
@@ -36,7 +36,7 @@ func NewRepository(db *mongo.Database, logger *zap.Logger) *Repository {
 // The input parameter [q *ObservationQuery] define the filters to apply in the query.
 func (r *Repository) Find(ctx context.Context, q *ObservationQuery) ([]*ObservationDoc, error) {
 
-	// Sort observations by descending timestamp
+	// Sort observations in descending timestamp order
 	sort := bson.D{{"indexedAt", -1}}
 
 	cur, err := r.collections.observations.Find(ctx, q.toBSON(), options.Find().SetLimit(q.Limit).SetSkip(q.Skip).SetSort(sort))

--- a/api/routes/wormscan/observations/controller.go
+++ b/api/routes/wormscan/observations/controller.go
@@ -25,7 +25,7 @@ func NewController(srv *observations.Service, logger *zap.Logger) *Controller {
 }
 
 // FindAll godoc
-// @Description Returns all observations.
+// @Description Returns all observations, sorted by descending timestamp.
 // @Tags Wormscan
 // @ID find-observations
 // @Param page query integer false "Page number."
@@ -51,7 +51,7 @@ func (c *Controller) FindAll(ctx *fiber.Ctx) error {
 }
 
 // FindAllByChain godoc
-// @Description Returns all observations for a given blockchain.
+// @Description Returns all observations for a given blockchain, sorted by descending timestamp.
 // @Tags Wormscan
 // @ID find-observations-by-chain
 // @Param page query integer false "Page number."
@@ -82,7 +82,7 @@ func (c *Controller) FindAllByChain(ctx *fiber.Ctx) error {
 }
 
 // FindAllByEmitter godoc
-// @Description Returns all observations for a specific emitter address.
+// @Description Returns all observations for a specific emitter address, sorted by descending timestamp.
 // @Tags Wormscan
 // @ID find-observations-by-emitter
 // @Param page query integer false "Page number."

--- a/api/routes/wormscan/observations/controller.go
+++ b/api/routes/wormscan/observations/controller.go
@@ -25,7 +25,7 @@ func NewController(srv *observations.Service, logger *zap.Logger) *Controller {
 }
 
 // FindAll godoc
-// @Description Returns all observations, sorted by descending timestamp.
+// @Description Returns all observations, sorted in descending timestamp order.
 // @Tags Wormscan
 // @ID find-observations
 // @Param page query integer false "Page number."
@@ -51,7 +51,7 @@ func (c *Controller) FindAll(ctx *fiber.Ctx) error {
 }
 
 // FindAllByChain godoc
-// @Description Returns all observations for a given blockchain, sorted by descending timestamp.
+// @Description Returns all observations for a given blockchain, sorted in descending timestamp order.
 // @Tags Wormscan
 // @ID find-observations-by-chain
 // @Param page query integer false "Page number."
@@ -82,7 +82,7 @@ func (c *Controller) FindAllByChain(ctx *fiber.Ctx) error {
 }
 
 // FindAllByEmitter godoc
-// @Description Returns all observations for a specific emitter address, sorted by descending timestamp.
+// @Description Returns all observations for a specific emitter address, sorted in descending timestamp order.
 // @Tags Wormscan
 // @ID find-observations-by-emitter
 // @Param page query integer false "Page number."


### PR DESCRIPTION
### Summary

This pull request fixes an issue in which all observation-related endpoints were returning results sorted by `id` (https://github.com/wormhole-foundation/wormhole-explorer/issues/358). The expected behavior is to sort results based on descending timestamp order instead.

Also, swagger docs were updated to document this behavior.