### PR TITLE
Fix an infinite loop in redis cache client

### DIFF
--- a/common/client/cache/notional/cache.go
+++ b/common/client/cache/notional/cache.go
@@ -70,6 +70,7 @@ func NewNotionalCache(ctx context.Context, redisClient *redis.Client, channel st
 
 // Init subscribe to notional pubsub and load the cache.
 func (c *NotionalCache) Init(ctx context.Context) error {
+
 	// load notional cache
 	err := c.loadCache(ctx)
 	if err != nil {
@@ -84,13 +85,21 @@ func (c *NotionalCache) Init(ctx context.Context) error {
 
 // loadCache load notional cache from redis.
 func (c *NotionalCache) loadCache(ctx context.Context) error {
-	scanCom := c.client.Scan(ctx, 0, wormscanNotionalCacheKeyRegex, 100)
+
+	var cursor uint64
+	var err error
 	for {
-		// Scan for notional keys
-		keys, cursor, err := scanCom.Result()
+		// Get a page of results from the cursor
+		var keys []string
+		scanCmd := c.client.Scan(ctx, cursor, wormscanNotionalCacheKeyRegex, 100)
+		if scanCmd.Err() != nil {
+			c.logger.Error("redis.ScanCmd has errors", zap.Error(err))
+			return fmt.Errorf("redis.ScanCmd has errors: %w", err)
+		}
+		keys, cursor, err = scanCmd.Result()
 		if err != nil {
-			c.logger.Error("loadCache", zap.Error(err))
-			return err
+			c.logger.Error("call to redis.ScanCmd.Result() failed", zap.Error(err))
+			return fmt.Errorf("call to redis.Client.Scan() failed: %w", err)
 		}
 
 		// Get notional value from keys
@@ -106,11 +115,11 @@ func (c *NotionalCache) loadCache(ctx context.Context) error {
 			c.notionalMap.Store(key, field)
 		}
 
+		// If we've reached the end of the cursor, return
 		if cursor == 0 {
-			break
+			return nil
 		}
 	}
-	return nil
 }
 
 // Subscribe to a notional update channel and load new values for the notional cache.

--- a/common/client/cache/notional/cache.go
+++ b/common/client/cache/notional/cache.go
@@ -99,7 +99,7 @@ func (c *NotionalCache) loadCache(ctx context.Context) error {
 		keys, cursor, err = scanCmd.Result()
 		if err != nil {
 			c.logger.Error("call to redis.ScanCmd.Result() failed", zap.Error(err))
-			return fmt.Errorf("call to redis.Client.Scan() failed: %w", err)
+			return fmt.Errorf("call to redis.ScanCmd.Result() failed: %w", err)
 		}
 
 		// Get notional value from keys


### PR DESCRIPTION
When initializing the notional cache, if there was more than one page of results, the client would run into an infinite loop.

This issue was causing several services to stall on startup in the staging environment (API, analytics, etc).

(For an example of how we're supposed to iterate over redis `Scan()` results, check this [documentation](https://pkg.go.dev/github.com/go-Redis/redis#Client.Scan))