### PR TITLE
Add support for Aptos in the `tx-tracker` service

### DIFF
--- a/api/routes/wormscan/transactions/controller.go
+++ b/api/routes/wormscan/transactions/controller.go
@@ -399,14 +399,17 @@ func (c *Controller) ListTransactions(ctx *fiber.Ctx) error {
 			UsdAmount:          queryResult.Transactions[i].UsdAmount,
 		}
 
-		// For Solana VAAs, the txHash that we get from the gossip network is not the real transacion hash,
-		// so we have to overwrite it with the real txHash.
-		if queryResult.Transactions[i].EmitterChain == sdk.ChainIDSolana &&
-			len(queryResult.Transactions[i].GlobalTransations) == 1 &&
-			queryResult.Transactions[i].GlobalTransations[0].OriginTx != nil {
+		// Set the transaction hash
+		isSolanaOrAptos := queryResult.Transactions[i].EmitterChain == sdk.ChainIDSolana ||
+			queryResult.Transactions[i].EmitterChain == sdk.ChainIDAptos
+		if isSolanaOrAptos {
+			// For Solana and Aptos VAAs, the txHash that we get from the gossip network is
+			// not the real transacion hash. We have to overwrite it with the real one.
+			if len(queryResult.Transactions[i].GlobalTransations) == 1 &&
+				queryResult.Transactions[i].GlobalTransations[0].OriginTx != nil {
 
-			tx.TxHash = queryResult.Transactions[i].GlobalTransations[0].OriginTx.TxHash
-
+				tx.TxHash = queryResult.Transactions[i].GlobalTransations[0].OriginTx.TxHash
+			}
 		} else {
 			tx.TxHash = queryResult.Transactions[i].TxHash
 		}

--- a/deploy/tx-tracker-backfiller/tx-tracker-backfiller-job.yaml
+++ b/deploy/tx-tracker-backfiller/tx-tracker-backfiller-job.yaml
@@ -31,6 +31,10 @@ spec:
                 configMapKeyRef:
                   name: config
                   key: mongo-database
+            - name: APTOS_BASE_URL
+              value: {{ .APTOS_BASE_URL }}
+            - name: APTOS_REQUESTS_PER_MINUTE
+              value: "{{ .APTOS_REQUESTS_PER_MINUTE }}"
             - name: ARBITRUM_BASE_URL
               value: {{ .ARBITRUM_BASE_URL }}
             - name: ARBITRUM_REQUESTS_PER_MINUTE

--- a/deploy/tx-tracker/tx-tracker-service.yaml
+++ b/deploy/tx-tracker/tx-tracker-service.yaml
@@ -57,6 +57,10 @@ spec:
               value: {{ .SQS_URL }}
             - name: AWS_REGION
               value: {{ .SQS_AWS_REGION }}
+            - name: APTOS_BASE_URL
+              value: {{ .APTOS_BASE_URL }}
+            - name: APTOS_REQUESTS_PER_MINUTE
+              value: "{{ .APTOS_REQUESTS_PER_MINUTE }}"
             - name: ARBITRUM_BASE_URL
               value: {{ .ARBITRUM_BASE_URL }}
             - name: ARBITRUM_REQUESTS_PER_MINUTE

--- a/tx-tracker/chains/aptos.go
+++ b/tx-tracker/chains/aptos.go
@@ -1,0 +1,92 @@
+package chains
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/wormhole-foundation/wormhole-explorer/txtracker/config"
+)
+
+const (
+	aptosCoreContractAddress = "0x5bc11445584a763c1fa7ed39081f1b920954da14e04b32440cba863d03e19625"
+)
+
+type aptosEvent struct {
+	Version uint64 `json:"version,string"`
+}
+
+type aptosTx struct {
+	Timestamp uint64 `json:"timestamp,string"`
+	Sender    string `json:"sender"`
+	Hash      string `json:"hash"`
+}
+
+func fetchAptosTx(
+	ctx context.Context,
+	cfg *config.RpcProviderSettings,
+	txHash string,
+) (*TxDetail, error) {
+
+	// Parse the Aptos event creation number
+	creationNumber, err := strconv.ParseUint(txHash, 16, 64)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse event creation number from Aptos tx hash: %w", err)
+	}
+
+	// Get the event from the Aptos node API.
+	var events []aptosEvent
+	{
+		// Build the URI for the events endpoint
+		uri := fmt.Sprintf("%s/accounts/%s/events/%s::state::WormholeMessageHandle/event?start=%d&limit=1",
+			cfg.AptosBaseUrl,
+			aptosCoreContractAddress,
+			aptosCoreContractAddress,
+			creationNumber,
+		)
+
+		// Query the events endpoint
+		body, err := httpGet(ctx, uri)
+		if err != nil {
+			return nil, fmt.Errorf("failed to query events endpoint: %w", err)
+		}
+
+		// Deserialize the response
+		err = json.Unmarshal(body, &events)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse response body from events endpoint: %w", err)
+		}
+	}
+	if len(events) != 1 {
+		return nil, fmt.Errorf("expected exactly one event, but got %d", len(events))
+	}
+
+	// Get the transacton
+	var tx aptosTx
+	{
+		// Build the URI for the events endpoint
+		uri := fmt.Sprintf("%s/transactions/by_version/%d", cfg.AptosBaseUrl, events[0].Version)
+
+		// Query the events endpoint
+		body, err := httpGet(ctx, uri)
+		if err != nil {
+			return nil, fmt.Errorf("failed to query transactions endpoint: %w", err)
+		}
+
+		// Deserialize the response
+		err = json.Unmarshal(body, &tx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse response body from transactions endpoint: %w", err)
+		}
+	}
+
+	// Build the result struct and return
+	TxDetail := TxDetail{
+		NativeTxHash: tx.Hash,
+		From:         tx.Sender,
+		Timestamp:    time.UnixMicro(int64(tx.Timestamp)),
+	}
+	return &TxDetail, nil
+}

--- a/tx-tracker/cmd/fetchone/main.go
+++ b/tx-tracker/cmd/fetchone/main.go
@@ -37,6 +37,5 @@ func main() {
 	}
 
 	// print tx details
-	log.Printf("tx detail: sender=%s nativeTxHash=%s timestamp=%s",
-		txDetail.From, txDetail.NativeTxHash, txDetail.Timestamp)
+	log.Printf("tx detail: %+v", txDetail)
 }

--- a/tx-tracker/config/structs.go
+++ b/tx-tracker/config/structs.go
@@ -59,6 +59,8 @@ type MongodbSettings struct {
 }
 
 type RpcProviderSettings struct {
+	AptosBaseUrl               string `split_words:"true" required:"true"`
+	AptosRequestsPerMinute     uint16 `split_words:"true" required:"true"`
 	ArbitrumBaseUrl            string `split_words:"true" required:"true"`
 	ArbitrumRequestsPerMinute  uint16 `split_words:"true" required:"true"`
 	AvalancheBaseUrl           string `split_words:"true" required:"true"`


### PR DESCRIPTION
### Description

This pull request adds support for Aptos in the `tx-tracker` service.

This will lead to improvements for the wormhole Scan UI:
1. The transaction hash that was being previously displayed for Aptos VAAs was incorrect. This pull request fixes the issue.
2. The sender addresses for Aptos VAAs will now become available for for the UI.