### PR TITLE
Add Moonbeam support in the `tx-tracker` service

### DIFF
--- a/deploy/tx-tracker-backfiller/tx-tracker-backfiller-job.yaml
+++ b/deploy/tx-tracker-backfiller/tx-tracker-backfiller-job.yaml
@@ -59,6 +59,10 @@ spec:
               value: {{ .FANTOM_BASE_URL }}
             - name: FANTOM_REQUESTS_PER_MINUTE
               value: "{{ .FANTOM_REQUESTS_PER_MINUTE }}"
+            - name: MOONBEAM_BASE_URL
+              value: {{ .MOONBEAM_BASE_URL }}
+            - name: MOONBEAM_REQUESTS_PER_MINUTE
+              value: "{{ .MOONBEAM_REQUESTS_PER_MINUTE }}"
             - name: OPTIMISM_BASE_URL
               value: {{ .OPTIMISM_BASE_URL }}
             - name: OPTIMISM_REQUESTS_PER_MINUTE

--- a/deploy/tx-tracker/tx-tracker-service.yaml
+++ b/deploy/tx-tracker/tx-tracker-service.yaml
@@ -85,6 +85,10 @@ spec:
               value: {{ .FANTOM_BASE_URL }}
             - name: FANTOM_REQUESTS_PER_MINUTE
               value: "{{ .FANTOM_REQUESTS_PER_MINUTE }}"
+            - name: MOONBEAM_BASE_URL
+              value: {{ .MOONBEAM_BASE_URL }}
+            - name: MOONBEAM_REQUESTS_PER_MINUTE
+              value: "{{ .MOONBEAM_REQUESTS_PER_MINUTE }}"
             - name: OPTIMISM_BASE_URL
               value: {{ .OPTIMISM_BASE_URL }}
             - name: OPTIMISM_REQUESTS_PER_MINUTE

--- a/tx-tracker/chains/tx.go
+++ b/tx-tracker/chains/tx.go
@@ -32,16 +32,17 @@ type TxDetail struct {
 }
 
 var tickers = struct {
+	aptos     *time.Ticker
 	arbitrum  *time.Ticker
 	avalanche *time.Ticker
 	bsc       *time.Ticker
 	celo      *time.Ticker
 	ethereum  *time.Ticker
 	fantom    *time.Ticker
+	moonbeam  *time.Ticker
 	optimism  *time.Ticker
 	polygon   *time.Ticker
 	solana    *time.Ticker
-	aptos     *time.Ticker
 	sui       *time.Ticker
 }{}
 
@@ -67,6 +68,7 @@ func Initialize(cfg *config.RpcProviderSettings) {
 	tickers.celo = time.NewTicker(f(cfg.CeloRequestsPerMinute / 2))
 	tickers.ethereum = time.NewTicker(f(cfg.EthereumRequestsPerMinute / 2))
 	tickers.fantom = time.NewTicker(f(cfg.FantomRequestsPerMinute / 2))
+	tickers.moonbeam = time.NewTicker(f(cfg.MoonbeamRequestsPerMinute / 2))
 	tickers.optimism = time.NewTicker(f(cfg.OptimismRequestsPerMinute / 2))
 	tickers.polygon = time.NewTicker(f(cfg.PolygonRequestsPerMinute / 2))
 	tickers.solana = time.NewTicker(f(cfg.SolanaRequestsPerMinute / 2))
@@ -125,6 +127,11 @@ func FetchTx(
 	case vaa.ChainIDAvalanche:
 		fetchFunc = func(ctx context.Context, cfg *config.RpcProviderSettings, txHash string) (*TxDetail, error) {
 			return fetchEthTx(ctx, txHash, cfg.AvalancheBaseUrl)
+		}
+		rateLimiter = *tickers.avalanche
+	case vaa.ChainIDMoonbeam:
+		fetchFunc = func(ctx context.Context, cfg *config.RpcProviderSettings, txHash string) (*TxDetail, error) {
+			return fetchEthTx(ctx, txHash, cfg.MoonbeamBaseUrl)
 		}
 		rateLimiter = *tickers.avalanche
 	case vaa.ChainIDAptos:

--- a/tx-tracker/config/structs.go
+++ b/tx-tracker/config/structs.go
@@ -73,6 +73,8 @@ type RpcProviderSettings struct {
 	EthereumRequestsPerMinute  uint16 `split_words:"true" required:"true"`
 	FantomBaseUrl              string `split_words:"true" required:"true"`
 	FantomRequestsPerMinute    uint16 `split_words:"true" required:"true"`
+	MoonbeamBaseUrl            string `split_words:"true" required:"true"`
+	MoonbeamRequestsPerMinute  uint16 `split_words:"true" required:"true"`
 	OptimismBaseUrl            string `split_words:"true" required:"true"`
 	OptimismRequestsPerMinute  uint16 `split_words:"true" required:"true"`
 	PolygonBaseUrl             string `split_words:"true" required:"true"`


### PR DESCRIPTION
### Description

This pull request modifies the `tx-tracker` service to support the Moonbeam blockchain.

In particular, this will make Moonbeam sender addresses available for the Wormhole Scan UI.