### PR TITLE
Fix tx hash parsing for Solana

### DIFF
--- a/api/types/tx_hash.go
+++ b/api/types/tx_hash.go
@@ -9,10 +9,13 @@ import (
 	"github.com/mr-tron/base58"
 )
 
-const solanaTxHashLen = 88
-const algorandTxHashLen = 52
-const wormholeMinTxHashLen = 64
-const wormholeMaxTxHashLen = 66
+const (
+	algorandTxHashLen    = 52
+	wormholeMinTxHashLen = 64
+	wormholeMaxTxHashLen = 66
+	solanaMinTxHashLen   = 87
+	solanaMaxTxHashLen   = 88
+)
 
 // TxHash represents a transaction hash passed by query params.
 type TxHash struct {
@@ -32,7 +35,7 @@ type TxHash struct {
 func ParseTxHash(value string) (*TxHash, error) {
 
 	// Solana txHashes are 64 bytes long, encoded as base58.
-	if len(value) == solanaTxHashLen {
+	if len(value) >= solanaMinTxHashLen && len(value) <= solanaMaxTxHashLen {
 		return parseSolanaTxHash(value)
 	}
 

--- a/api/types/tx_hash_test.go
+++ b/api/types/tx_hash_test.go
@@ -13,17 +13,23 @@ func TestParseTxHash(t *testing.T) {
 		isWormholeTxHash bool
 	}{
 		{
-			// Solana hash
+			// Solana hash - 88 characters
 			input:          "2maR6uDZzroV7JFF76rp5QR4CFP1PFUe76VRE8gF8QtWRifpGAKJQo4SQDBNs3TAM9RrchJhnJ644jUL2yfagZco",
 			output:         "2maR6uDZzroV7JFF76rp5QR4CFP1PFUe76VRE8gF8QtWRifpGAKJQo4SQDBNs3TAM9RrchJhnJ644jUL2yfagZco",
 			isSolanaTxHash: true,
 		},
 		{
-			// Solana hash w/ invalid length
-			input: "2maR6uDZzroV7JFF76rp5QR4CFP1PFUe76VRE8gF8QtWRifpGAKJQo4SQDBNs3TAM9RrchJhnJ644jUL2yfagZc",
+			// Solana hash - 87 characters
+			input:          "VKrJx5ak3amnpY5EXiqfu6pnrzxHTLU95m9vfbYnGSSLQrkRzb4tm4NztCGeLcJxieXQYnqddUwoaEsDRTRh57R",
+			output:         "VKrJx5ak3amnpY5EXiqfu6pnrzxHTLU95m9vfbYnGSSLQrkRzb4tm4NztCGeLcJxieXQYnqddUwoaEsDRTRh57R",
+			isSolanaTxHash: true,
 		},
 		{
-			// Solana hash w/ invalid length
+			// Solana hash w/ invalid length (86 characters)
+			input: "VKrJx5ak3amnpY5EXiqfu6pnrzxHTLU95m9vfbYnGSSLQrkRzb4tm4NztCGeLcJxieXQYnqddUwoaEsDRTRh57",
+		},
+		{
+			// Solana hash w/ invalid length (89 characters)
 			input: "2maR6uDZzroV7JFF76rp5QR4CFP1PFUe76VRE8gF8QtWRifpGAKJQo4SQDBNs3TAM9RrchJhnJ644jUL2yfagZco2",
 		},
 		{


### PR DESCRIPTION
### Description

Tracking issue: https://github.com/wormhole-foundation/wormhole-explorer/issues/434

Some Solana transaction hashes were failing to parse. This pull request fixes the issue.