### PR TITLE
Fix transaction hash search for Sui

### DIFF
--- a/api/types/tx_hash_test.go
+++ b/api/types/tx_hash_test.go
@@ -33,6 +33,26 @@ func TestParseTxHash(t *testing.T) {
 			input: "2maR6uDZzroV7JFF76rp5QR4CFP1PFUe76VRE8gF8QtWRifpGAKJQo4SQDBNs3TAM9RrchJhnJ644jUL2yfagZco2",
 		},
 		{
+			// Invalid Sui hash - 42 characters (too short)
+			input: "cVWa8xZtWbTxXQGLQaYquwmChE2sQYxFNGnHmp6oXX",
+		},
+		{
+			// Valid Sui hash - 43 characters
+			input:            "cVWa8xZtWbTxXQGLQaYquwmChE2sQYxFNGnHmp6oXXL",
+			output:           "cVWa8xZtWbTxXQGLQaYquwmChE2sQYxFNGnHmp6oXXL",
+			isWormholeTxHash: true,
+		},
+		{
+			// Valid Sui hash - 44 characters
+			input:            "9yQWLTNmFkwZ6CdK3QXhk8utKr42n3Eh1CFFBWcdCeJC",
+			output:           "9yQWLTNmFkwZ6CdK3QXhk8utKr42n3Eh1CFFBWcdCeJC",
+			isWormholeTxHash: true,
+		},
+		{
+			// Invalid Sui hash - 45 characters (too long)
+			input: "9yQWLTNmFkwZ6CdK3QXhk8utKr42n3Eh1CFFBWcdCeJC9",
+		},
+		{
 			// Wormhole hash with 0x prefix
 			input:            "0x3f77f8b44f35ff047a74ee8235ce007afbab357d4e30010d51b6f6990f921637",
 			output:           "3f77f8b44f35ff047a74ee8235ce007afbab357d4e30010d51b6f6990f921637",


### PR DESCRIPTION
### Description

Tracking issue: https://github.com/wormhole-foundation/wormhole-explorer/issues/447

For Sui transaction hashes, calling `GET /api/v1/vaas?txHash={hash}` returned an HTTP status code of 400 and a message of `"MALFORMED TX HASH"`.

This pull request fixes the problem.

