### PR TITLE
Remove field `vaa.NativeTxHash` from JSON model

### DIFF
--- a/api/handlers/vaa/model.go
+++ b/api/handlers/vaa/model.go
@@ -35,7 +35,7 @@ type VaaDoc struct {
 	// NativeTxHash is an internal field.
 	//
 	// It is not intended to be accessed by consumers of this package.
-	NativeTxHash string `bson:"nativeTxHash"`
+	NativeTxHash string `bson:"nativeTxHash" json:"-"`
 }
 
 // MarshalJSON interface implementation.


### PR DESCRIPTION
### Description

Remove the `NativeTxHash` from the JSON model returned by `GET /api/v1/vaas`. That field was never meant to be exposed to the API users.