### PR TITLE
Improvements in the `tx-tracker` service

### DIFF
--- a/tx-tracker/cmd/service/main.go
+++ b/tx-tracker/cmd/service/main.go
@@ -121,7 +121,7 @@ func newSqsConsumer(ctx context.Context, cfg *config.ServiceSettings) (*sqs.Cons
 		// of traffic (e.g.: dozens of VAAs being emitted in the same minute), and
 		// also when a we have to retry fetching transaction metadata many times
 		// (due to finality delay, out-of-sync nodes, etc).
-		sqs.WithVisibilityTimeout(15*60),
+		sqs.WithVisibilityTimeout(20*60),
 	)
 	return consumer, err
 }

--- a/tx-tracker/consumer/consumer.go
+++ b/tx-tracker/consumer/consumer.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/wormhole-foundation/wormhole-explorer/txtracker/config"
 	"github.com/wormhole-foundation/wormhole-explorer/txtracker/queue"
-	sdk "github.com/wormhole-foundation/wormhole/sdk/vaa"
 	"go.uber.org/zap"
 )
 
@@ -57,28 +56,13 @@ func (c *Consumer) producerLoop(ctx context.Context) {
 
 	for msg := range ch {
 
-		event := msg.Data()
-
-		// Check if message is expired.
-		if msg.IsExpired() {
-			c.logger.Warn("Message with VAA expired", zap.String("id", event.ID))
-			msg.Failed()
-			continue
-		}
-
-		// Do not process messages from PythNet
-		if event.ChainID == sdk.ChainIDPythNet {
-			msg.Done()
-			continue
-		}
-
 		// Send the VAA to the worker pool.
 		//
 		// The worker pool is responsible for calling `msg.Done()`
 		err := c.workerPool.Push(ctx, msg)
 		if err != nil {
 			c.logger.Warn("failed to push message into worker pool",
-				zap.String("vaaId", event.ID),
+				zap.String("vaaId", msg.Data().ID),
 				zap.Error(err),
 			)
 			msg.Failed()

--- a/tx-tracker/consumer/processor.go
+++ b/tx-tracker/consumer/processor.go
@@ -80,7 +80,6 @@ func ProcessSourceTx(
 	p := UpsertDocumentParams{
 		VaaId:    params.VaaId,
 		ChainId:  params.ChainId,
-		TxHash:   params.TxHash,
 		TxDetail: txDetail,
 		TxStatus: txStatus,
 	}

--- a/tx-tracker/consumer/repository.go
+++ b/tx-tracker/consumer/repository.go
@@ -40,7 +40,6 @@ func NewRepository(logger *zap.Logger, db *mongo.Database) *Repository {
 type UpsertDocumentParams struct {
 	VaaId    string
 	ChainId  sdk.ChainID
-	TxHash   string
 	TxDetail *chains.TxDetail
 	TxStatus domain.SourceTxStatus
 }

--- a/tx-tracker/queue/vaa_sqs.go
+++ b/tx-tracker/queue/vaa_sqs.go
@@ -112,7 +112,13 @@ func (m *sqsConsumerMessage) Data() *VaaEvent {
 
 func (m *sqsConsumerMessage) Done() {
 	if err := m.consumer.DeleteMessage(m.ctx, m.id); err != nil {
-		m.logger.Error("Error deleting message from SQS", zap.Error(err))
+		m.logger.Error("Error deleting message from SQS",
+			zap.String("vaaId", m.data.ID),
+			zap.Bool("isExpired", m.IsExpired()),
+			zap.Time("expiredAt", m.expiredAt),
+			zap.Time("now", time.Now()),
+			zap.Error(err),
+		)
 	}
 	m.wg.Done()
 }

--- a/tx-tracker/queue/vaa_sqs.go
+++ b/tx-tracker/queue/vaa_sqs.go
@@ -116,7 +116,6 @@ func (m *sqsConsumerMessage) Done() {
 			zap.String("vaaId", m.data.ID),
 			zap.Bool("isExpired", m.IsExpired()),
 			zap.Time("expiredAt", m.expiredAt),
-			zap.Time("now", time.Now()),
 			zap.Error(err),
 		)
 	}


### PR DESCRIPTION
### Description

This pull request implements improvements in the `tx-tracker` service:
* Adjust SQS visibilityTimeout.
* Process PythNet messages concurrently (this will make it easier for the service to catch up if there are a lot of messages in the input queue).
* Add more context information to error messages.