### PR TITLE
Remove unused fields from the origin transaction model

### DIFF
--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -2591,16 +2591,10 @@ const docTemplate = `{
         "transactions.OriginTx": {
             "type": "object",
             "properties": {
-                "chainId": {
-                    "$ref": "#/definitions/vaa.ChainID"
-                },
                 "from": {
                     "type": "string"
                 },
                 "status": {
-                    "type": "string"
-                },
-                "timestamp": {
                     "type": "string"
                 },
                 "txHash": {

--- a/api/docs/swagger.json
+++ b/api/docs/swagger.json
@@ -2584,16 +2584,10 @@
         "transactions.OriginTx": {
             "type": "object",
             "properties": {
-                "chainId": {
-                    "$ref": "#/definitions/vaa.ChainID"
-                },
                 "from": {
                     "type": "string"
                 },
                 "status": {
-                    "type": "string"
-                },
-                "timestamp": {
                     "type": "string"
                 },
                 "txHash": {

--- a/api/docs/swagger.yaml
+++ b/api/docs/swagger.yaml
@@ -541,13 +541,9 @@ definitions:
     type: object
   transactions.OriginTx:
     properties:
-      chainId:
-        $ref: '#/definitions/vaa.ChainID'
       from:
         type: string
       status:
-        type: string
-      timestamp:
         type: string
       txHash:
         type: string

--- a/api/handlers/transactions/model.go
+++ b/api/handlers/transactions/model.go
@@ -76,11 +76,9 @@ type GlobalTransactionDoc struct {
 
 // OriginTx representa a origin transaction.
 type OriginTx struct {
-	ChainID   sdk.ChainID `bson:"chainId" json:"chainId"`
-	TxHash    string      `bson:"nativeTxHash" json:"txHash"`
-	Timestamp *time.Time  `bson:"timestamp" json:"timestamp"`
-	From      string      `bson:"from" json:"from"`
-	Status    string      `bson:"status" json:"status"`
+	TxHash string `bson:"nativeTxHash" json:"txHash"`
+	From   string `bson:"from" json:"from"`
+	Status string `bson:"status" json:"status"`
 }
 
 // DestinationTx representa a destination transaction.

--- a/api/handlers/transactions/repository.go
+++ b/api/handlers/transactions/repository.go
@@ -656,8 +656,6 @@ func (r *Repository) FindGlobalTransactionByID(ctx context.Context, q *GlobalTra
 		}
 	default:
 		result = globalTransaction
-		result.OriginTx.Timestamp = originTx.Timestamp
-		result.OriginTx.ChainID = originTx.ChainID
 	}
 
 	return result, nil
@@ -692,9 +690,7 @@ func (r *Repository) findOriginTxFromVaa(ctx context.Context, q *GlobalTransacti
 
 	// populate the result and return
 	originTx := OriginTx{
-		Timestamp: &record.Timestamp,
-		ChainID:   record.EmitterChain,
-		Status:    string(domain.SourceTxStatusConfirmed),
+		Status: string(domain.SourceTxStatusConfirmed),
 	}
 	if record.EmitterChain != sdk.ChainIDSolana && record.EmitterChain != sdk.ChainIDAptos {
 		originTx.TxHash = record.TxHash


### PR DESCRIPTION
### Description

This pull request removes two unused fields from the `GlobalTransaction.OriginTx` JSON model:
* `timestamp`: this field is always set to the VAA's timestamp, making it redundant. Moreover, for EVM chains we need one extra RPC node request to get it. So better get rid of it.
* `chainId`: this field is always set to the VAA's emitter chain, making it redundant.