### PR TITLE
Handle multiple VAAs with the same `txHash`

### DIFF
--- a/api/handlers/vaa/service.go
+++ b/api/handlers/vaa/service.go
@@ -183,12 +183,9 @@ func (s *Service) findById(
 }
 
 // GetVaaCount get a list a list of vaa count grouped by chainID.
-func (s *Service) GetVaaCount(ctx context.Context, p *pagination.Pagination) (*response.Response[[]*VaaStats], error) {
-	if p == nil {
-		p = pagination.Default()
-	}
-	query := Query().SetPagination(p)
-	stats, err := s.repo.GetVaaCount(ctx, query)
+func (s *Service) GetVaaCount(ctx context.Context) (*response.Response[[]*VaaStats], error) {
+	q := Query()
+	stats, err := s.repo.GetVaaCount(ctx, q)
 	res := response.Response[[]*VaaStats]{Data: stats}
 	return &res, err
 }

--- a/api/handlers/vaa/service.go
+++ b/api/handlers/vaa/service.go
@@ -78,7 +78,7 @@ func (s *Service) FindAll(
 		return nil, err
 	}
 
-	// Eeturn the matching documents
+	// Return the matching documents
 	res := response.Response[[]*VaaDoc]{Data: vaas}
 	return &res, nil
 }

--- a/api/routes/wormscan/vaa/controller.go
+++ b/api/routes/wormscan/vaa/controller.go
@@ -183,12 +183,7 @@ func (c *Controller) FindById(ctx *fiber.Ctx) error {
 // @Router /api/v1/vaas/vaa-counts [get]
 func (c *Controller) GetVaaCount(ctx *fiber.Ctx) error {
 
-	p, err := middleware.ExtractPagination(ctx)
-	if err != nil {
-		return err
-	}
-
-	vaas, err := c.srv.GetVaaCount(ctx.Context(), p)
+	vaas, err := c.srv.GetVaaCount(ctx.Context())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Description

Before this pull request, when calling `GET /api/v1/vaas?txHash={h}` for a hash that has multiple VAAs associated with it, we were just returning one. After this pull request, the API should return all of the VAAs associated with that transaction hash.

Tracking issue: https://github.com/wormhole-foundation/wormhole-explorer/issues/563