### PR TITLE
`tx-tracker`: add support for the "Base" blockchain

### DIFF
--- a/common/domain/chainid.go
+++ b/common/domain/chainid.go
@@ -244,6 +244,7 @@ func DecodeNativeAddressToHex(chainID sdk.ChainID, address string) (string, erro
 	// EVM chains use the classic hex, 0x-prefixed encoding.
 	// Also, Karura and Acala support EVM-compatible addresses, so they're handled here as well.
 	case sdk.ChainIDEthereum,
+		sdk.ChainIDBase,
 		sdk.ChainIDBSC,
 		sdk.ChainIDPolygon,
 		sdk.ChainIDAvalanche,

--- a/common/domain/chainid.go
+++ b/common/domain/chainid.go
@@ -72,23 +72,23 @@ func TranslateEmitterAddress(chainID sdk.ChainID, address string) (string, error
 
 	// Terra addresses use bench32 encoding
 	case sdk.ChainIDTerra:
-		return encodeBench32("terra", addressBytes[12:])
+		return encodeBech32("terra", addressBytes[12:])
 
 	// Terra2 addresses use bench32 encoding
 	case sdk.ChainIDTerra2:
-		return encodeBench32("terra", addressBytes)
+		return encodeBech32("terra", addressBytes)
 
 	// Injective addresses use bench32 encoding
 	case sdk.ChainIDInjective:
-		return encodeBench32("inj", addressBytes[12:])
+		return encodeBech32("inj", addressBytes[12:])
 
 	// Xpla addresses use bench32 encoding
 	case sdk.ChainIDXpla:
-		return encodeBench32("xpla", addressBytes)
+		return encodeBech32("xpla", addressBytes)
 
 	// Sei addresses use bench32 encoding
 	case sdk.ChainIDSei:
-		return encodeBench32("sei", addressBytes)
+		return encodeBech32("sei", addressBytes)
 
 	// Algorand addresses use base32 encoding with a trailing checksum.
 	// We're using the SDK to handle the checksum logic.
@@ -136,17 +136,6 @@ func TranslateEmitterAddress(chainID sdk.ChainID, address string) (string, error
 	default:
 		return "", fmt.Errorf("can't translate emitter address: ChainID=%d not supported", chainID)
 	}
-}
-
-// encodeBench32 is a helper function to encode bench32 addresses.
-func encodeBench32(hrp string, data []byte) (string, error) {
-
-	aligned, err := bech32.ConvertBits(data, 8, 5, true)
-	if err != nil {
-		return "", fmt.Errorf("bech32 encoding failed: %w", err)
-	}
-
-	return bech32.Encode(hrp, aligned)
 }
 
 // GetSupportedChainIDs returns a map of all supported chain IDs to their respective names.
@@ -303,7 +292,7 @@ func DecodeNativeAddressToHex(chainID sdk.ChainID, address string) (string, erro
 	}
 }
 
-// decodeBech32 is a helper function to decode bech32 addresses.
+// decodeBech32 is a helper function to decode a bech32 addresses.
 func decodeBech32(h, address string) (string, error) {
 
 	hrp, decoded, err := bech32.Decode(address, bech32.MaxLengthBIP173)
@@ -311,8 +300,19 @@ func decodeBech32(h, address string) (string, error) {
 		return "", fmt.Errorf("bech32 decoding failed: %w", err)
 	}
 	if hrp != h {
-		return "", fmt.Errorf("bech32 decoding failed: invalid prefix: %s", hrp)
+		return "", fmt.Errorf("bech32 decoding failed, invalid prefix: %s", hrp)
 	}
 
 	return hex.EncodeToString(decoded), nil
+}
+
+// encodeBech32 is a helper function to encode a bech32 addresses.
+func encodeBech32(hrp string, data []byte) (string, error) {
+
+	aligned, err := bech32.ConvertBits(data, 8, 5, true)
+	if err != nil {
+		return "", fmt.Errorf("bech32 encoding failed: %w", err)
+	}
+
+	return bech32.Encode(hrp, aligned)
 }

--- a/common/domain/chainid.go
+++ b/common/domain/chainid.go
@@ -53,6 +53,7 @@ func TranslateEmitterAddress(chainID sdk.ChainID, address string) (string, error
 	// EVM chains use the classic hex, 0x-prefixed encoding.
 	// Also, Karura and Acala support EVM-compatible addresses, so they're handled here as well.
 	case sdk.ChainIDEthereum,
+		sdk.ChainIDBase,
 		sdk.ChainIDBSC,
 		sdk.ChainIDPolygon,
 		sdk.ChainIDAvalanche,
@@ -213,7 +214,6 @@ func EncodeTrxHashByChainID(chainID sdk.ChainID, txHash []byte) (string, error) 
 		//TODO: check if this is correct
 		return hex.EncodeToString(txHash), nil
 	case sdk.ChainIDBase:
-		//TODO: check if this is correct
 		return hex.EncodeToString(txHash), nil
 	case sdk.ChainIDSei:
 		return hex.EncodeToString(txHash), nil

--- a/deploy/tx-tracker-backfiller/env/production.env
+++ b/deploy/tx-tracker-backfiller/env/production.env
@@ -28,6 +28,9 @@ ARBITRUM_REQUESTS_PER_MINUTE=1
 AVALANCHE_BASE_URL=https://api.avax.network/ext/bc/C/rpc
 AVALANCHE_REQUESTS_PER_MINUTE=2
 
+BASE_BASE_URL=https://base-mainnet.public.blastapi.io
+BASE_REQUESTS_PER_MINUTE=1
+
 BSC_BASE_URL=https://bsc-dataseed2.defibit.io
 BSC_REQUESTS_PER_MINUTE=2
 

--- a/deploy/tx-tracker-backfiller/env/staging.env
+++ b/deploy/tx-tracker-backfiller/env/staging.env
@@ -28,6 +28,9 @@ ARBITRUM_REQUESTS_PER_MINUTE=1
 AVALANCHE_BASE_URL=https://api.avax.network/ext/bc/C/rpc
 AVALANCHE_REQUESTS_PER_MINUTE=1
 
+BASE_BASE_URL=https://base-mainnet.public.blastapi.io
+BASE_REQUESTS_PER_MINUTE=1
+
 BSC_BASE_URL=https://bsc-dataseed2.defibit.io
 BSC_REQUESTS_PER_MINUTE=1
 

--- a/deploy/tx-tracker-backfiller/env/test.env
+++ b/deploy/tx-tracker-backfiller/env/test.env
@@ -28,6 +28,9 @@ ARBITRUM_REQUESTS_PER_MINUTE=2
 AVALANCHE_BASE_URL=https://rpc.ankr.com/avalanche_fuji
 AVALANCHE_REQUESTS_PER_MINUTE=2
 
+BASE_BASE_URL=https://base-goerli.public.blastapi.io
+BASE_REQUESTS_PER_MINUTE=1
+
 BSC_BASE_URL=https://data-seed-prebsc-1-s1.binance.org:8545
 BSC_REQUESTS_PER_MINUTE=2
 

--- a/deploy/tx-tracker/env/production.env
+++ b/deploy/tx-tracker/env/production.env
@@ -27,6 +27,9 @@ ARBITRUM_REQUESTS_PER_MINUTE=12
 AVALANCHE_BASE_URL=https://api.avax.network/ext/bc/C/rpc
 AVALANCHE_REQUESTS_PER_MINUTE=12
 
+BASE_BASE_URL=https://base-mainnet.public.blastapi.io
+BASE_REQUESTS_PER_MINUTE=12
+
 BSC_BASE_URL=https://bsc-dataseed2.defibit.io
 BSC_REQUESTS_PER_MINUTE=12
 

--- a/deploy/tx-tracker/env/staging.env
+++ b/deploy/tx-tracker/env/staging.env
@@ -27,6 +27,9 @@ ARBITRUM_REQUESTS_PER_MINUTE=12
 AVALANCHE_BASE_URL=https://api.avax.network/ext/bc/C/rpc
 AVALANCHE_REQUESTS_PER_MINUTE=12
 
+BASE_BASE_URL=https://base-mainnet.public.blastapi.io
+BASE_REQUESTS_PER_MINUTE=12
+
 BSC_BASE_URL=https://bsc-dataseed2.defibit.io
 BSC_REQUESTS_PER_MINUTE=12
 

--- a/deploy/tx-tracker/env/test.env
+++ b/deploy/tx-tracker/env/test.env
@@ -27,6 +27,9 @@ ARBITRUM_REQUESTS_PER_MINUTE=12
 AVALANCHE_BASE_URL=https://rpc.ankr.com/avalanche_fuji
 AVALANCHE_REQUESTS_PER_MINUTE=12
 
+BASE_BASE_URL=https://base-goerli.public.blastapi.io
+BASE_REQUESTS_PER_MINUTE=12
+
 BSC_BASE_URL=https://data-seed-prebsc-1-s1.binance.org:8545
 BSC_REQUESTS_PER_MINUTE=12
 

--- a/tx-tracker/chains/chains.go
+++ b/tx-tracker/chains/chains.go
@@ -50,6 +50,7 @@ func Initialize(cfg *config.RpcProviderSettings) {
 	rateLimitersByChain[sdk.ChainIDAlgorand] = convertToRateLimiter(cfg.AlgorandRequestsPerMinute)
 	rateLimitersByChain[sdk.ChainIDAptos] = convertToRateLimiter(cfg.AptosRequestsPerMinute)
 	rateLimitersByChain[sdk.ChainIDAvalanche] = convertToRateLimiter(cfg.AvalancheRequestsPerMinute)
+	rateLimitersByChain[sdk.ChainIDBase] = convertToRateLimiter(cfg.BaseRequestsPerMinute)
 	rateLimitersByChain[sdk.ChainIDBSC] = convertToRateLimiter(cfg.BscRequestsPerMinute)
 	rateLimitersByChain[sdk.ChainIDCelo] = convertToRateLimiter(cfg.CeloRequestsPerMinute)
 	rateLimitersByChain[sdk.ChainIDEthereum] = convertToRateLimiter(cfg.EthereumRequestsPerMinute)
@@ -74,6 +75,7 @@ func Initialize(cfg *config.RpcProviderSettings) {
 	baseUrlsByChain[sdk.ChainIDAlgorand] = cfg.AlgorandBaseUrl
 	baseUrlsByChain[sdk.ChainIDAptos] = cfg.AptosBaseUrl
 	baseUrlsByChain[sdk.ChainIDAvalanche] = cfg.AvalancheBaseUrl
+	baseUrlsByChain[sdk.ChainIDBase] = cfg.BaseBaseUrl
 	baseUrlsByChain[sdk.ChainIDBSC] = cfg.BscBaseUrl
 	baseUrlsByChain[sdk.ChainIDCelo] = cfg.CeloBaseUrl
 	baseUrlsByChain[sdk.ChainIDEthereum] = cfg.EthereumBaseUrl
@@ -118,6 +120,7 @@ func FetchTx(
 	case sdk.ChainIDAcala,
 		sdk.ChainIDArbitrum,
 		sdk.ChainIDAvalanche,
+		sdk.ChainIDBase,
 		sdk.ChainIDBSC,
 		sdk.ChainIDCelo,
 		sdk.ChainIDEthereum,

--- a/tx-tracker/config/structs.go
+++ b/tx-tracker/config/structs.go
@@ -70,6 +70,8 @@ type RpcProviderSettings struct {
 	ArbitrumRequestsPerMinute  uint16 `split_words:"true" required:"true"`
 	AvalancheBaseUrl           string `split_words:"true" required:"true"`
 	AvalancheRequestsPerMinute uint16 `split_words:"true" required:"true"`
+	BaseBaseUrl                string `split_words:"true" required:"true"`
+	BaseRequestsPerMinute      uint16 `split_words:"true" required:"true"`
 	BscBaseUrl                 string `split_words:"true" required:"true"`
 	BscRequestsPerMinute       uint16 `split_words:"true" required:"true"`
 	CeloBaseUrl                string `split_words:"true" required:"true"`


### PR DESCRIPTION
### Description

Tracking issue: https://github.com/wormhole-foundation/wormhole-explorer/issues/569

This pull request adds support for the "Base" blockchain in different parts of the codebase:
* The functions `domain.TranslateEmitterAddress`, `domain.EncodeTrxHashByChainID` and `domain.DecodeNativeAddressToHex`.
* The `tx-tracker` service: it now connects to a Base RPC node to fetch origin transaction metadata.