### PR TITLE
[API] Add `toChain` filter to `GET /api/v1/vaas/{emitterChain}/{emitterAddr}`

### DIFF
--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -1289,6 +1289,12 @@ const docTemplate = `{
                     },
                     {
                         "type": "integer",
+                        "description": "destination chain",
+                        "name": "toChain",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
                         "description": "Page number.",
                         "name": "page",
                         "in": "query"

--- a/api/docs/swagger.json
+++ b/api/docs/swagger.json
@@ -1282,6 +1282,12 @@
                     },
                     {
                         "type": "integer",
+                        "description": "destination chain",
+                        "name": "toChain",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
                         "description": "Page number.",
                         "name": "page",
                         "in": "query"

--- a/api/docs/swagger.yaml
+++ b/api/docs/swagger.yaml
@@ -1611,6 +1611,10 @@ paths:
         name: emitter
         required: true
         type: string
+      - description: destination chain
+        in: query
+        name: toChain
+        type: integer
       - description: Page number.
         in: query
         name: page

--- a/api/handlers/vaa/repository.go
+++ b/api/handlers/vaa/repository.go
@@ -126,9 +126,6 @@ func (r *Repository) FindVaasByEmitterAndToChain(
 	// build a query pipeline based on input parameters
 	var pipeline mongo.Pipeline
 	{
-		// specify sorting criteria
-		pipeline = append(pipeline, bson.D{{"$sort", bson.D{bson.E{"indexedAt", query.GetSortInt()}}}})
-
 		// filter by emitterChain, emitterAddr, and toChain
 		pipeline = append(pipeline, bson.D{
 			{"$match", bson.D{bson.E{"emitterChain", query.chainId}}},
@@ -139,6 +136,9 @@ func (r *Repository) FindVaasByEmitterAndToChain(
 		pipeline = append(pipeline, bson.D{
 			{"$match", bson.D{bson.E{"rawStandardizedProperties.toChain", toChain}}},
 		})
+
+		// specify sorting criteria
+		pipeline = append(pipeline, bson.D{{"$sort", bson.D{bson.E{"indexedAt", query.GetSortInt()}}}})
 
 		// skip initial results
 		if query.Pagination.Skip != 0 {

--- a/api/handlers/vaa/repository.go
+++ b/api/handlers/vaa/repository.go
@@ -117,6 +117,7 @@ func (r *Repository) FindVaasByTxHashWorkaround(
 	return r.FindVaas(ctx, &q)
 }
 
+// FindVaasByEmitterAndToChain searches the database for VAAs that match a given emitter chain, address and toChain.
 func (r *Repository) FindVaasByEmitterAndToChain(
 	ctx context.Context,
 	query *VaaQuery,

--- a/api/handlers/vaa/repository.go
+++ b/api/handlers/vaa/repository.go
@@ -127,7 +127,7 @@ func (r *Repository) FindVaasByEmitterAndToChain(
 	var pipeline mongo.Pipeline
 	{
 		// specify sorting criteria
-		pipeline = append(pipeline, bson.D{{"$sort", bson.D{query.getSortPredicate()}}})
+		pipeline = append(pipeline, bson.D{{"$sort", bson.D{bson.E{"indexedAt", query.GetSortInt()}}}})
 
 		// filter by emitterChain, emitterAddr, and toChain
 		pipeline = append(pipeline, bson.D{

--- a/api/handlers/vaa/repository.go
+++ b/api/handlers/vaa/repository.go
@@ -21,6 +21,7 @@ type Repository struct {
 	logger      *zap.Logger
 	collections struct {
 		vaas               *mongo.Collection
+		parsedVaa          *mongo.Collection
 		vaasPythnet        *mongo.Collection
 		invalidVaas        *mongo.Collection
 		vaaCount           *mongo.Collection
@@ -34,12 +35,14 @@ func NewRepository(db *mongo.Database, logger *zap.Logger) *Repository {
 		logger: logger.With(zap.String("module", "VaaRepository")),
 		collections: struct {
 			vaas               *mongo.Collection
+			parsedVaa          *mongo.Collection
 			vaasPythnet        *mongo.Collection
 			invalidVaas        *mongo.Collection
 			vaaCount           *mongo.Collection
 			globalTransactions *mongo.Collection
 		}{
 			vaas:               db.Collection("vaas"),
+			parsedVaa:          db.Collection("parsedVaa"),
 			vaasPythnet:        db.Collection("vaasPythnet"),
 			invalidVaas:        db.Collection("invalid_vaas"),
 			vaaCount:           db.Collection("vaaCounts"),
@@ -111,6 +114,80 @@ func (r *Repository) FindVaasByTxHashWorkaround(
 	// may be different that the transaction hash in the `vaas` collection. This is the case
 	// for Aptos and Solana VAAs.
 	q.txHash = ""
+	return r.FindVaas(ctx, &q)
+}
+
+func (r *Repository) FindVaasByEmitterAndToChain(
+	ctx context.Context,
+	query *VaaQuery,
+	toChain sdk.ChainID,
+) ([]*VaaDoc, error) {
+
+	// build a query pipeline based on input parameters
+	var pipeline mongo.Pipeline
+	{
+		// specify sorting criteria
+		pipeline = append(pipeline, bson.D{{"$sort", bson.D{query.getSortPredicate()}}})
+
+		// filter by emitterChain, emitterAddr, and toChain
+		pipeline = append(pipeline, bson.D{
+			{"$match", bson.D{bson.E{"emitterChain", query.chainId}}},
+		})
+		pipeline = append(pipeline, bson.D{
+			{"$match", bson.D{bson.E{"emitterAddr", query.emitter}}},
+		})
+		pipeline = append(pipeline, bson.D{
+			{"$match", bson.D{bson.E{"rawStandardizedProperties.toChain", toChain}}},
+		})
+
+		// skip initial results
+		if query.Pagination.Skip != 0 {
+			pipeline = append(pipeline, bson.D{{"$skip", query.Pagination.Skip}})
+		}
+
+		// limit size of results
+		pipeline = append(pipeline, bson.D{{"$limit", query.Pagination.Limit}})
+	}
+
+	// execute the aggregation pipeline
+	cur, err := r.collections.parsedVaa.Aggregate(ctx, pipeline)
+	if err != nil {
+		requestID := fmt.Sprintf("%v", ctx.Value("requestid"))
+		r.logger.Error("failed execute Aggregate command to get vaa by emitter and toChain",
+			zap.Error(err),
+			zap.Any("q", query),
+			zap.Any("toChain", toChain),
+			zap.String("requestID", requestID),
+		)
+		return nil, errors.WithStack(err)
+	}
+
+	// read results from cursor
+	var vaas []struct {
+		ID string `bson:"_id"`
+	}
+	err = cur.All(ctx, &vaas)
+	if err != nil {
+		requestID := fmt.Sprintf("%v", ctx.Value("requestid"))
+		r.logger.Error("failed to decode cursor",
+			zap.Error(err),
+			zap.Any("q", query),
+			zap.Any("toChain", toChain),
+			zap.String("requestID", requestID),
+		)
+		return nil, errors.WithStack(err)
+	}
+
+	// if no results were found, return an empty slice instead of nil.
+	if len(vaas) == 0 {
+		return make([]*VaaDoc, 0), nil
+	}
+
+	// call FindVaas with the IDs we've found
+	q := *query // make a copy to avoid modifying the struct passed by the caller
+	for _, vaa := range vaas {
+		q.ids = append(q.ids, vaa.ID)
+	}
 	return r.FindVaas(ctx, &q)
 }
 

--- a/api/handlers/vaa/service.go
+++ b/api/handlers/vaa/service.go
@@ -101,21 +101,26 @@ func (s *Service) FindByChain(
 	return &res, err
 }
 
+// FindByEmitterParams contains the input parameters for the function `FindByEmitter`.
+type FindByEmitterParams struct {
+	EmitterChain         sdk.ChainID
+	EmitterAddress       *types.Address
+	ToChain              *sdk.ChainID
+	IncludeParsedPayload bool
+	Pagination           *pagination.Pagination
+}
+
 // FindByEmitter get all the vaa by chainID and emitter address.
 func (s *Service) FindByEmitter(
 	ctx context.Context,
-	emitterChain sdk.ChainID,
-	emitterAddress *types.Address,
-	toChain *sdk.ChainID,
-	includeParsedPayload bool,
-	p *pagination.Pagination,
+	params *FindByEmitterParams,
 ) (*response.Response[[]*VaaDoc], error) {
 
 	query := Query().
-		SetChain(emitterChain).
-		SetEmitter(emitterAddress.Hex()).
-		SetPagination(p).
-		IncludeParsedPayload(includeParsedPayload)
+		SetChain(params.EmitterChain).
+		SetEmitter(params.EmitterAddress.Hex()).
+		SetPagination(params.Pagination).
+		IncludeParsedPayload(params.IncludeParsedPayload)
 
 	// In most cases, the data is obtained from the VAA collection.
 	//
@@ -123,8 +128,8 @@ func (s *Service) FindByEmitter(
 	// the data from a different collection.
 	var vaas []*VaaDoc
 	var err error
-	if toChain != nil {
-		vaas, err = s.repo.FindVaasByEmitterAndToChain(ctx, query, *toChain)
+	if params.ToChain != nil {
+		vaas, err = s.repo.FindVaasByEmitterAndToChain(ctx, query, *params.ToChain)
 	} else {
 		vaas, err = s.repo.FindVaas(ctx, query)
 	}

--- a/api/middleware/extract_parameters.go
+++ b/api/middleware/extract_parameters.go
@@ -35,6 +35,28 @@ func ExtractChainID(c *fiber.Ctx, l *zap.Logger) (sdk.ChainID, error) {
 	return sdk.ChainID(chain), nil
 }
 
+func ExtractToChain(c *fiber.Ctx, l *zap.Logger) (*sdk.ChainID, error) {
+
+	param := c.Query("toChain")
+	if param == "" {
+		return nil, nil
+	}
+
+	chain, err := strconv.ParseInt(param, 10, 16)
+	if err != nil {
+		requestID := fmt.Sprintf("%v", c.Locals("requestid"))
+		l.Error("failed to parse toChain parameter",
+			zap.Error(err),
+			zap.String("requestID", requestID),
+		)
+
+		return nil, response.NewInvalidParamError(c, "INVALID TO_CHAIN VALUE", errors.WithStack(err))
+	}
+
+	result := sdk.ChainID(chain)
+	return &result, nil
+}
+
 // ExtractEmitterAddr parses the emitter address from the request path.
 //
 // When the parameter `chainIdHint` is not nil, this function will attempt to parse the

--- a/api/middleware/extract_parameters.go
+++ b/api/middleware/extract_parameters.go
@@ -35,6 +35,9 @@ func ExtractChainID(c *fiber.Ctx, l *zap.Logger) (sdk.ChainID, error) {
 	return sdk.ChainID(chain), nil
 }
 
+// ExtractFromChain obtains the "toChain" query parameter from the request.
+//
+// When the parameter is not present, the function returns: a nil ChainID and a nil error.
 func ExtractToChain(c *fiber.Ctx, l *zap.Logger) (*sdk.ChainID, error) {
 
 	param := c.Query("toChain")

--- a/api/routes/wormscan/vaa/controller.go
+++ b/api/routes/wormscan/vaa/controller.go
@@ -128,7 +128,17 @@ func (c *Controller) FindByEmitter(ctx *fiber.Ctx) error {
 		return err
 	}
 
-	vaas, err := c.srv.FindByEmitter(ctx.Context(), chainID, emitter, p)
+	toChain, err := middleware.ExtractToChain(ctx, c.logger)
+	if err != nil {
+		return err
+	}
+
+	includeParsedPayload, err := middleware.ExtractParsedPayload(ctx, c.logger)
+	if err != nil {
+		return err
+	}
+
+	vaas, err := c.srv.FindByEmitter(ctx.Context(), chainID, emitter, toChain, includeParsedPayload, p)
 	if err != nil {
 		return err
 	}

--- a/api/routes/wormscan/vaa/controller.go
+++ b/api/routes/wormscan/vaa/controller.go
@@ -109,7 +109,7 @@ func (c *Controller) FindByChain(ctx *fiber.Ctx) error {
 // @ID find-vaas-by-emitter
 // @Param chain_id path integer true "id of the blockchain"
 // @Param emitter path string true "address of the emitter"
-// @Param toChain quuery integer false "destination chain"
+// @Param toChain query integer false "destination chain"
 // @Param page query integer false "Page number."
 // @Param pageSize query integer false "Number of elements per page."
 // @Param sortOrder query string false "Sort results in ascending or descending order." Enums(ASC, DESC)

--- a/api/routes/wormscan/vaa/controller.go
+++ b/api/routes/wormscan/vaa/controller.go
@@ -109,6 +109,7 @@ func (c *Controller) FindByChain(ctx *fiber.Ctx) error {
 // @ID find-vaas-by-emitter
 // @Param chain_id path integer true "id of the blockchain"
 // @Param emitter path string true "address of the emitter"
+// @Param toChain quuery integer false "destination chain"
 // @Param page query integer false "Page number."
 // @Param pageSize query integer false "Number of elements per page."
 // @Param sortOrder query string false "Sort results in ascending or descending order." Enums(ASC, DESC)

--- a/api/routes/wormscan/vaa/controller.go
+++ b/api/routes/wormscan/vaa/controller.go
@@ -119,27 +119,33 @@ func (c *Controller) FindByChain(ctx *fiber.Ctx) error {
 // @Router /api/v1/vaas/{chain_id}/{emitter} [get]
 func (c *Controller) FindByEmitter(ctx *fiber.Ctx) error {
 
-	p, err := middleware.ExtractPagination(ctx)
+	// Get query parameters
+	pagination, err := middleware.ExtractPagination(ctx)
 	if err != nil {
 		return err
 	}
-
 	chainID, emitter, err := middleware.ExtractVAAChainIDEmitter(ctx, c.logger)
 	if err != nil {
 		return err
 	}
-
 	toChain, err := middleware.ExtractToChain(ctx, c.logger)
 	if err != nil {
 		return err
 	}
-
 	includeParsedPayload, err := middleware.ExtractParsedPayload(ctx, c.logger)
 	if err != nil {
 		return err
 	}
 
-	vaas, err := c.srv.FindByEmitter(ctx.Context(), chainID, emitter, toChain, includeParsedPayload, p)
+	// Call the VAA service
+	p := vaa.FindByEmitterParams{
+		EmitterChain:         chainID,
+		EmitterAddress:       emitter,
+		ToChain:              toChain,
+		IncludeParsedPayload: includeParsedPayload,
+		Pagination:           pagination,
+	}
+	vaas, err := c.srv.FindByEmitter(ctx.Context(), &p)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Description

This pull request adds the parameter `toChain` to the endpoint `GET /api/v1/vaas/{emitterChain}/{emitterAddress}`.

Other VAA-related endpoints do not support this parameter.

Additionally, for performance reasons, a composite index must be created in MongoDB: `db.parsedVaa.createIndex({"emitterChain": -1, "emitterAddr": -1, "rawStandardizedProperties.toChain": -1, "indexedAt": -1})`