### PR TITLE
fix(.gitignore): ignore files from event-watcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,16 @@
 .idea/
 .vscode/
 go.work.sum
+
+# Event watcher
+node_modules/
+lib/
+dist/
+*.log
+db.json
+lastBlockByChain.json
+.env
+serviceAccountKey.json
+bigtableAccountKey.json
+tsconfig.tsbuildinfo
+serviceAccount.json


### PR DESCRIPTION
# Description

Update `.gitignore` file to ignore these files from `event-watcher` folder:

> node_modules/
> lib/
> dist/
> *.log
> db.json
> lastBlockByChain.json
> .env
> serviceAccountKey.json
> bigtableAccountKey.json
> tsconfig.tsbuildinfo
> serviceAccount.json