### PR TITLE
fix: persist behavior when finding redeemed events

### DIFF
--- a/event-watcher/src/consts.ts
+++ b/event-watcher/src/consts.ts
@@ -32,7 +32,7 @@ export const RPCS_BY_CHAIN_MAINNET: { [key in ChainName]?: string } = {
   aptos: env.APTOS_RPC || 'https://fullnode.mainnet.aptoslabs.com',
   arbitrum: env.ARBITRUM_RPC || 'https://arb1.arbitrum.io/rpc',
   avalanche: env.AVALANCHE_RPC || 'https://rpc.ankr.com/avalanche',
-  base: env.BASE_RPC || 'https://developer-access-mainnet.base.org',
+  base: env.BASE_RPC || 'https://rpc.ankr.com/base',
   bsc: env.BSC_RPC || 'https://rpc.ankr.com/bsc_testnet_chapel',
   celo: env.CELO_RPC || 'https://forno.celo.org',
   ethereum: env.ETHEREUM_RPC || 'https://eth.llamarpc.com', // 'https://svc.blockdaemon.com/ethereum/mainnet/native',

--- a/event-watcher/src/databases/types.ts
+++ b/event-watcher/src/databases/types.ts
@@ -57,10 +57,15 @@ export type WHTransferRedeemed = {
   id: string;
   destinationTx: {
     chainId: number;
+    txHash: string;
     status: string;
     method: string;
+    from: string;
+    to: string;
+    blockNumber: string;
     timestamp: Date;
     updatedAt: Date;
   };
+  indexedAt: Date | string | number;
   revision: number;
 };

--- a/event-watcher/src/databases/utils.ts
+++ b/event-watcher/src/databases/utils.ts
@@ -83,24 +83,47 @@ export const makeWHRedeemedTransaction = async ({
   emitterChainId,
   emitterAddress,
   sequence,
+  txHash,
+  from,
+  to,
+  blockNumber,
+  indexedAt,
 }: {
+  txHash: string;
   emitterChainId: number;
   emitterAddress: string;
   sequence: number;
+  from: string;
+  to: string;
+  blockNumber: string;
+  indexedAt: Date | number | string;
 }): Promise<WHTransferRedeemed> => {
   const vaaId = `${emitterChainId}/${emitterAddress}/${sequence}`;
   const REDEEMED_TX_STATUS = 'completed';
   const REDEEMED_TX_METHOD = 'event-watcher-redeemed';
 
+  let parsedIndexedAt = indexedAt;
+
+  if (!(parsedIndexedAt instanceof Date)) {
+    if (!checkIfDateIsInMilliseconds(parsedIndexedAt)) {
+      parsedIndexedAt = new Date(+parsedIndexedAt * 1000) as unknown as number;
+    }
+  }
+
   return {
     id: vaaId,
     destinationTx: {
       chainId: emitterChainId,
+      txHash,
       status: REDEEMED_TX_STATUS,
       method: REDEEMED_TX_METHOD,
+      from,
+      to,
+      blockNumber, // hex string(16)
       timestamp: new Date(),
       updatedAt: new Date(),
     },
+    indexedAt: parsedIndexedAt,
     revision: 1,
   };
 };

--- a/event-watcher/src/index.ts
+++ b/event-watcher/src/index.ts
@@ -15,7 +15,7 @@ import { logInfo } from './utils/logger';
 import { ChainName } from '@certusone/wormhole-sdk';
 import { NETWORK } from './consts';
 
-const version = '1.1.0';
+const version = '1.2.0';
 class EventWatcher {
   private watchers: WatcherOptionTypes[] = [];
 


### PR DESCRIPTION
# Description 

- Enhance behavior when finding the `TransferRedeemed` event

### Criteria

1. If the document does not exist -> insert the document with data available from logs
2. If the document does exist
   2.1. if `destinationTx` field does not exist -> insert the `destinationTx` field into the document with data available from logs
   2.2 if `destinationTx` field exists -> **none**

