### PR TITLE
fix-853/validate-undefined-log-map

### DIFF
--- a/blockchain-watcher/src/infrastructure/repositories/EvmJsonRPCBlockRepository.ts
+++ b/blockchain-watcher/src/infrastructure/repositories/EvmJsonRPCBlockRepository.ts
@@ -149,12 +149,14 @@ export class EvmJsonRPCBlockRepository implements EvmBlockRepository {
       )} from ${chainCfg.rpc.hostname}`
     );
 
-    return logs.map((log) => ({
-      ...log,
-      blockNumber: BigInt(log.blockNumber),
-      transactionIndex: log.transactionIndex.toString(),
-      chainId: chainCfg.chainId,
-    }));
+    return logs
+      ? logs.map((log) => ({
+          ...log,
+          blockNumber: BigInt(log.blockNumber),
+          transactionIndex: log.transactionIndex.toString(),
+          chainId: chainCfg.chainId,
+        }))
+      : [];
   }
 
   private describeFilter(filter: EvmLogFilter): string {

--- a/blockchain-watcher/test/infrastructure/repositories/EvmJsonRPCBlockRepository.integration.test.ts
+++ b/blockchain-watcher/test/infrastructure/repositories/EvmJsonRPCBlockRepository.integration.test.ts
@@ -23,6 +23,13 @@ describe("EvmJsonRPCBlockRepository", () => {
     nock.cleanAll();
   });
 
+  const filter: EvmLogFilter = {
+    fromBlock: "safe",
+    toBlock: "latest",
+    addresses: [address],
+    topics: [],
+  };
+
   it("should be able to get block height", async () => {
     const expectedHeight = 1980809n;
     givenARepo();
@@ -47,13 +54,6 @@ describe("EvmJsonRPCBlockRepository", () => {
   });
 
   it("should be able to get logs", async () => {
-    const filter: EvmLogFilter = {
-      fromBlock: "safe",
-      toBlock: "latest",
-      addresses: [address],
-      topics: [],
-    };
-
     givenLogsPresent(filter);
 
     const logs = await repo.getFilteredLogs(eth, filter);
@@ -62,6 +62,20 @@ describe("EvmJsonRPCBlockRepository", () => {
     expect(logs[0].blockNumber).toBe(1n);
     expect(logs[0].blockHash).toBe(blockHash(1n));
     expect(logs[0].address).toBe(address);
+  });
+
+  it("should be able to return empty array", async () => {
+    const response = {
+      jsonrpc: "2.0",
+      id: 1,
+      result: [],
+    };
+
+    nock(rpc).post("/").reply(200, response);
+
+    const logs = await repo.getFilteredLogs(eth, filter);
+
+    expect(logs).toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
## Link Issue
- https://github.com/wormhole-foundation/wormhole-explorer/issues/853

## Description
- Fix undefined logs map when get logs. When tried to get records do not validate if result is different to undefined. This happen in EVM chains in getFilteredLogs method

## Test or Screenshots
 - 1: Validate if logs are undefined or null 
<img width="1277" alt="image" src="https://github.com/wormhole-foundation/wormhole-explorer/assets/52217955/52b424cd-8079-44ea-892d-b30077957a2e">

 - 2: If is undefined or null, return a empty array 
<img width="593" alt="image" src="https://github.com/wormhole-foundation/wormhole-explorer/assets/52217955/456d4a71-5ee5-40bf-a000-5b123c00ab99">

Test
![Screenshot 2023-12-04 at 10 42 00](https://github.com/wormhole-foundation/wormhole-explorer/assets/52217955/a3cdfd6e-799a-4a1c-81a3-a704cd654b83)