### PR TITLE
Add Avalanche Portico contract address

### DIFF
--- a/contract-watcher/config/mainnet.go
+++ b/contract-watcher/config/mainnet.go
@@ -215,6 +215,12 @@ var AVALANCHE_MAINNET = WatcherBlockchainAddresses{
 				Name: MetehodCompleteTransferWithRelay,
 			},
 		},
+		strings.ToLower("0xE565E118e75304dD3cF83dff409c90034b7EA18a"): {
+			{
+				ID:   MethodIDReceiveMessageAndSwap,
+				Name: MethodReceiveMessageAndSwap,
+			},
+		},
 	},
 }
 


### PR DESCRIPTION
The purpose of this PR is to add the Avalanche Portico contract address so redeem events can be picked up in the explorer.