### PR TITLE
bw: remove ankr public nodes usage

### DIFF
--- a/blockchain-watcher/config/default.json
+++ b/blockchain-watcher/config/default.json
@@ -32,21 +32,21 @@
       "name": "ethereum",
       "network": "goerli",
       "chainId": 2,
-      "rpcs": ["https://rpc.ankr.com/eth_goerli"],
+      "rpcs": ["https://ethereum-goerli.publicnode.com"],
       "timeout": 10000
     },
     "bsc": {
       "name": "bsc",
       "network": "BNB Smart Chain testnet",
       "chainId": 4,
-      "rpcs": ["https://rpc.ankr.com/bsc_testnet_chapel"],
+      "rpcs": ["https://endpoints.omniatech.io/v1/bsc/testnet/public"],
       "timeout": 10000
     },
     "polygon": {
       "name": "polygon",
       "network": "mumbai",
       "chainId": 5,
-      "rpcs": ["https://rpc.ankr.com/polygon_mumbai"],
+      "rpcs": ["https://rpc-mumbai.maticvigil.com"],
       "timeout": 10000
     },
     "avalanche": {

--- a/blockchain-watcher/config/mainnet.json
+++ b/blockchain-watcher/config/mainnet.json
@@ -7,7 +7,7 @@
     },
     "ethereum": {
       "network": "mainnet",
-      "rpcs": ["https://rpc.ankr.com/eth"]
+      "rpcs": ["https://endpoints.omniatech.io/v1/eth/mainnet/public"]
     },
     "bsc": {
       "network": "mainnet",
@@ -15,7 +15,7 @@
     },
     "polygon": {
       "network": "mainnet",
-      "rpcs": ["https://rpc.ankr.com/polygon"]
+      "rpcs": ["https://rpc-mainnet.matic.quiknode.pro"]
     },
     "avalanche": {
       "network": "mainnet",
@@ -51,11 +51,11 @@
     },
     "arbitrum": {
       "network": "mainnet",
-      "rpcs": ["https://rpc.ankr.com/arbitrum"]
+      "rpcs": ["https://arbitrum.blockpi.network/v1/rpc/public"]
     },
     "optimism": {
       "network": "mainnet",
-      "rpcs": ["https://rpc.ankr.com/optimism"]
+      "rpcs": ["https://op-pokt.nodies.app"]
     },
     "base": {
       "network": "mainnet",


### PR DESCRIPTION
Remove ankr public node usage in BW. Ankr looks at IPs to apply limits and could apply hard rate limiting on private nodes if we go over the threshold on public nodes.