### PR TITLE
[Blockchain Watcher] (FIX) Add lowecasse in contracts addresses

### DIFF
--- a/blockchain-watcher/src/domain/actions/evm/HandleEvmTransactions.ts
+++ b/blockchain-watcher/src/domain/actions/evm/HandleEvmTransactions.ts
@@ -25,10 +25,10 @@ export class HandleEvmTransactions<T> {
       return this.mapper(transaction);
     }) as T[];
 
-    await this.target(mappedItems);
+    const filterItems = mappedItems.filter((transaction) => transaction) as T[];
 
-    // TODO: return a result specifying failures if any
-    return mappedItems;
+    await this.target(filterItems);
+    return filterItems;
   }
 
   private normalizeCfg(cfg: HandleEvmLogsConfig): HandleEvmLogsConfig {

--- a/blockchain-watcher/src/infrastructure/mappers/evm/evmRedeemedTransactionFoundMapper.ts
+++ b/blockchain-watcher/src/infrastructure/mappers/evm/evmRedeemedTransactionFoundMapper.ts
@@ -109,7 +109,7 @@ const findProtocol = (
   for (const contract of contractsMapperConfig.contracts) {
     if (contract.chain === chain) {
       const foundProtocol = contract.protocols.find((protocol) =>
-        protocol.addresses.some((addr) => addr.toLowerCase() === address.toLowerCase())
+       protocol.addresses.some((addr) => addr.toLowerCase() === address.toLowerCase())
       );
       const foundMethod = foundProtocol?.methods.find(
         (method) => method.methodId === first10Characters
@@ -125,7 +125,7 @@ const findProtocol = (
   }
 
   logger.warn(
-    `[${chain}] Protocol not found, [tx hash: ${hash}][address: ${address}][input: ${input}]`
+    `[${chain}] Protocol not found, [tx hash: ${hash}][address: ${address}][input: ${first10Characters}]`
   );
 };
 

--- a/blockchain-watcher/src/infrastructure/mappers/evm/evmRedeemedTransactionFoundMapper.ts
+++ b/blockchain-watcher/src/infrastructure/mappers/evm/evmRedeemedTransactionFoundMapper.ts
@@ -109,7 +109,7 @@ const findProtocol = (
   for (const contract of contractsMapperConfig.contracts) {
     if (contract.chain === chain) {
       const foundProtocol = contract.protocols.find((protocol) =>
-       protocol.addresses.some((addr) => addr.toLowerCase() === address.toLowerCase())
+        protocol.addresses.some((addr) => addr.toLowerCase() === address.toLowerCase())
       );
       const foundMethod = foundProtocol?.methods.find(
         (method) => method.methodId === first10Characters

--- a/blockchain-watcher/src/infrastructure/mappers/evm/evmRedeemedTransactionFoundMapper.ts
+++ b/blockchain-watcher/src/infrastructure/mappers/evm/evmRedeemedTransactionFoundMapper.ts
@@ -109,7 +109,7 @@ const findProtocol = (
   for (const contract of contractsMapperConfig.contracts) {
     if (contract.chain === chain) {
       const foundProtocol = contract.protocols.find((protocol) =>
-        protocol.addresses.includes(address)
+        protocol.addresses.some((addr) => addr.toLowerCase() === address.toLowerCase())
       );
       const foundMethod = foundProtocol?.methods.find(
         (method) => method.methodId === first10Characters

--- a/blockchain-watcher/src/infrastructure/mappers/solana/solanaTransferRedeemedMapper.ts
+++ b/blockchain-watcher/src/infrastructure/mappers/solana/solanaTransferRedeemedMapper.ts
@@ -124,7 +124,7 @@ const findProtocol = (
   for (const contract of contractsMapperConfig.contracts) {
     if (contract.chain === chain) {
       const foundProtocol = contract.protocols.find((protocol) =>
-        protocol.addresses.includes(programId)
+        protocol.addresses.some((addr) => addr.toLowerCase() === programId.toLowerCase())
       );
       const foundMethod = foundProtocol?.methods.find(
         (method) => method.methodId === String(methodId)

--- a/blockchain-watcher/test/infrastructure/mappers/evm/evmRedeemedTransactionFoundMapper.test.ts
+++ b/blockchain-watcher/test/infrastructure/mappers/evm/evmRedeemedTransactionFoundMapper.test.ts
@@ -119,7 +119,7 @@ describe("evmRedeemedTransactionFoundMapper", () => {
     expect(result?.blockHeight).toBe(18793148n);
     expect(result?.attributes.blockNumber).toBe(18793148n);
     expect(result?.attributes.from).toBe("0xfb070adcd21361a3946a0584dc84a7b89faa68e3");
-    expect(result?.attributes.to).toBe("0x3ee18B2214AFF97000D974cf647E7C347E8fa585");
+    expect(result?.attributes.to).toBe("0x3ee18b2214aFF97000d974Cf647e7C347e8fa585");
     expect(result?.attributes.methodsByAddress).toBe("MethodCompleteTransfer");
     expect(result?.attributes.emitterChain).toBe(23);
     expect(result?.attributes.emitterAddress).toBe(

--- a/blockchain-watcher/test/infrastructure/mappers/evm/evmRedeemedTransactionFoundMapper.test.ts
+++ b/blockchain-watcher/test/infrastructure/mappers/evm/evmRedeemedTransactionFoundMapper.test.ts
@@ -91,7 +91,7 @@ describe("evmRedeemedTransactionFoundMapper", () => {
         s: "0x6dccc8cfee216bc43a9d66525fa94905da234ad32d6cc3220845bef78f25dd42",
         status: "0x1",
         timestamp: 1702663079,
-        to: "0x3ee18B2214AFF97000D974cf647E7C347E8fa585",
+        to: "0x3ee18b2214aFF97000d974Cf647e7C347e8fa585",
         transactionIndex: "0x6f",
         type: "0x2",
         v: "0x1",


### PR DESCRIPTION
## Link Issue
- 

## Description
- Fix when try to match contract address with address inside events

## Test or Screenshots
- 
<img width="740" alt="image" src="https://github.com/wormhole-foundation/wormhole-explorer/assets/52217955/8eb48c29-d2fc-4970-9391-673d7211b0da">

