### PR TITLE
[ISSUE-1220] Add filters to /operations endpoint

### DIFF
--- a/api/handlers/operations/repository.go
+++ b/api/handlers/operations/repository.go
@@ -259,30 +259,22 @@ func (r *Repository) FindByChainAndAppId(ctx context.Context, query OperationQue
 	// Limit size of results
 	pipeline = append(pipeline, bson.D{{Key: "$limit", Value: query.Pagination.Limit}})
 
-	//pipeline = append(pipeline, bson.D{{Key: "$lookup", Value: bson.D{{Key: "from", Value: "vaas"}, {Key: "localField", Value: "_id"}, {Key: "foreignField", Value: "_id"}, {Key: "as", Value: "vaas"}}}})
-
-	// lookup globalTransactions
-	//pipeline = append(pipeline, bson.D{{Key: "$lookup", Value: bson.D{{Key: "from", Value: "globalTransactions"}, {Key: "localField", Value: "_id"}, {Key: "foreignField", Value: "_id"}, {Key: "as", Value: "globalTransactions"}}}})
+	pipeline = append(pipeline, bson.D{{Key: "$lookup", Value: bson.D{{Key: "from", Value: "vaas"}, {Key: "localField", Value: "_id"}, {Key: "foreignField", Value: "_id"}, {Key: "as", Value: "vaas"}}}})
 
 	// lookup transferPrices
-	//pipeline = append(pipeline, bson.D{{Key: "$lookup", Value: bson.D{{Key: "from", Value: "transferPrices"}, {Key: "localField", Value: "_id"}, {Key: "foreignField", Value: "_id"}, {Key: "as", Value: "transferPrices"}}}})
-
-	// lookup parsedVaa
-	//pipeline = append(pipeline, bson.D{{Key: "$lookup", Value: bson.D{{Key: "from", Value: "parsedVaa"}, {Key: "localField", Value: "_id"}, {Key: "foreignField", Value: "_id"}, {Key: "as", Value: "parsedVaa"}}}})
+	pipeline = append(pipeline, bson.D{{Key: "$lookup", Value: bson.D{{Key: "from", Value: "transferPrices"}, {Key: "localField", Value: "_id"}, {Key: "foreignField", Value: "_id"}, {Key: "as", Value: "transferPrices"}}}})
 
 	// add fields
 	pipeline = append(pipeline, bson.D{{Key: "$addFields", Value: bson.D{
-		//{Key: "payload", Value: bson.D{{Key: "$arrayElemAt", Value: bson.A{"$parsedVaa.parsedPayload", 0}}}},
 		{Key: "payload", Value: "$parsedPayload"},
-		//{Key: "vaa", Value: bson.D{{Key: "$arrayElemAt", Value: bson.A{"$vaas", 0}}}},
-		//{Key: "standardizedProperties", Value: bson.D{{Key: "$arrayElemAt", Value: bson.A{"$parsedVaa.standardizedProperties", 0}}}},
-		//{Key: "symbol", Value: bson.D{{Key: "$arrayElemAt", Value: bson.A{"$transferPrices.symbol", 0}}}},
-		//{Key: "usdAmount", Value: bson.D{{Key: "$arrayElemAt", Value: bson.A{"$transferPrices.usdAmount", 0}}}},
-		//{Key: "tokenAmount", Value: bson.D{{Key: "$arrayElemAt", Value: bson.A{"$transferPrices.tokenAmount", 0}}}},
+		{Key: "vaa", Value: bson.D{{Key: "$arrayElemAt", Value: bson.A{"$vaas", 0}}}},
+		{Key: "symbol", Value: bson.D{{Key: "$arrayElemAt", Value: bson.A{"$transferPrices.symbol", 0}}}},
+		{Key: "usdAmount", Value: bson.D{{Key: "$arrayElemAt", Value: bson.A{"$transferPrices.usdAmount", 0}}}},
+		{Key: "tokenAmount", Value: bson.D{{Key: "$arrayElemAt", Value: bson.A{"$transferPrices.tokenAmount", 0}}}},
 	}}})
 
 	// unset
-	pipeline = append(pipeline, bson.D{{Key: "$unset", Value: bson.A{"transferPrices", "parsedVaa"}}})
+	pipeline = append(pipeline, bson.D{{Key: "$unset", Value: bson.A{"transferPrices"}}})
 
 	cur, err := r.collections.parsedVaa.Aggregate(ctx, pipeline)
 	if err != nil {

--- a/api/handlers/operations/repository.go
+++ b/api/handlers/operations/repository.go
@@ -259,13 +259,13 @@ func (r *Repository) FindByChainAndAppId(ctx context.Context, query OperationQue
 	// Limit size of results
 	pipeline = append(pipeline, bson.D{{Key: "$limit", Value: query.Pagination.Limit}})
 
-	pipeline = append(pipeline, bson.D{{Key: "$lookup", Value: bson.D{{Key: "from", Value: "vaas"}, {Key: "localField", Value: "_id"}, {Key: "foreignField", Value: "_id"}, {Key: "as", Value: "vaas"}}}})
+	//pipeline = append(pipeline, bson.D{{Key: "$lookup", Value: bson.D{{Key: "from", Value: "vaas"}, {Key: "localField", Value: "_id"}, {Key: "foreignField", Value: "_id"}, {Key: "as", Value: "vaas"}}}})
 
 	// lookup globalTransactions
 	//pipeline = append(pipeline, bson.D{{Key: "$lookup", Value: bson.D{{Key: "from", Value: "globalTransactions"}, {Key: "localField", Value: "_id"}, {Key: "foreignField", Value: "_id"}, {Key: "as", Value: "globalTransactions"}}}})
 
 	// lookup transferPrices
-	pipeline = append(pipeline, bson.D{{Key: "$lookup", Value: bson.D{{Key: "from", Value: "transferPrices"}, {Key: "localField", Value: "_id"}, {Key: "foreignField", Value: "_id"}, {Key: "as", Value: "transferPrices"}}}})
+	//pipeline = append(pipeline, bson.D{{Key: "$lookup", Value: bson.D{{Key: "from", Value: "transferPrices"}, {Key: "localField", Value: "_id"}, {Key: "foreignField", Value: "_id"}, {Key: "as", Value: "transferPrices"}}}})
 
 	// lookup parsedVaa
 	//pipeline = append(pipeline, bson.D{{Key: "$lookup", Value: bson.D{{Key: "from", Value: "parsedVaa"}, {Key: "localField", Value: "_id"}, {Key: "foreignField", Value: "_id"}, {Key: "as", Value: "parsedVaa"}}}})
@@ -274,11 +274,11 @@ func (r *Repository) FindByChainAndAppId(ctx context.Context, query OperationQue
 	pipeline = append(pipeline, bson.D{{Key: "$addFields", Value: bson.D{
 		//{Key: "payload", Value: bson.D{{Key: "$arrayElemAt", Value: bson.A{"$parsedVaa.parsedPayload", 0}}}},
 		{Key: "payload", Value: "$parsedPayload"},
-		{Key: "vaa", Value: bson.D{{Key: "$arrayElemAt", Value: bson.A{"$vaas", 0}}}},
+		//{Key: "vaa", Value: bson.D{{Key: "$arrayElemAt", Value: bson.A{"$vaas", 0}}}},
 		//{Key: "standardizedProperties", Value: bson.D{{Key: "$arrayElemAt", Value: bson.A{"$parsedVaa.standardizedProperties", 0}}}},
-		{Key: "symbol", Value: bson.D{{Key: "$arrayElemAt", Value: bson.A{"$transferPrices.symbol", 0}}}},
-		{Key: "usdAmount", Value: bson.D{{Key: "$arrayElemAt", Value: bson.A{"$transferPrices.usdAmount", 0}}}},
-		{Key: "tokenAmount", Value: bson.D{{Key: "$arrayElemAt", Value: bson.A{"$transferPrices.tokenAmount", 0}}}},
+		//{Key: "symbol", Value: bson.D{{Key: "$arrayElemAt", Value: bson.A{"$transferPrices.symbol", 0}}}},
+		//{Key: "usdAmount", Value: bson.D{{Key: "$arrayElemAt", Value: bson.A{"$transferPrices.usdAmount", 0}}}},
+		//{Key: "tokenAmount", Value: bson.D{{Key: "$arrayElemAt", Value: bson.A{"$transferPrices.tokenAmount", 0}}}},
 	}}})
 
 	// unset

--- a/api/handlers/operations/repository.go
+++ b/api/handlers/operations/repository.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/wormhole-foundation/wormhole/sdk/vaa"
-	"math"
 	"strings"
 
 	"github.com/wormhole-foundation/wormhole-explorer/api/internal/errors"
@@ -191,16 +190,17 @@ func findOperationsIdByPayloadType(ctx context.Context, db *mongo.Database, logg
 
 	logger.Info("findOperationsIdByPayloadType: building pipeline")
 
-	matchParsedVaa := bson.D{{Key: "$match", Value: bson.D{{Key: "$or", Value: bson.A{
-		bson.D{{Key: "parsedPayload.payloadType", Value: bson.M{"$eq": payloadType}}},
-	}}}}}
-	parserFilter := bson.D{{Key: "$unionWith", Value: bson.D{{Key: "coll", Value: "parsedVaa"}, {Key: "pipeline", Value: bson.A{matchParsedVaa}}}}}
-	group := bson.D{{Key: "$group", Value: bson.D{{Key: "_id", Value: "$_id"}}}}
-	pipeline := []bson.D{parserFilter, group}
+	matchPayloadType := bson.D{{Key: "parsedPayload.payloadType", Value: payloadType}}
+
+	// Pipeline to match documents and then group by _id
+	pipeline := mongo.Pipeline{
+		{{Key: "$match", Value: matchPayloadType}},
+		//{{Key: "$group", Value: bson.D{{Key: "_id", Value: "$_id"}}}},
+	}
 
 	logger.Info("findOperationsIdByPayloadType: finished building pipeline")
 
-	cur, err := db.Collection("_operationsTemporal").Aggregate(ctx, pipeline)
+	cur, err := db.Collection("parsedVaa").Aggregate(ctx, pipeline)
 	if err != nil {
 		logger.Error("failed execute aggregation pipeline for querying by payload type", zap.Error(err))
 		return nil, err
@@ -337,13 +337,8 @@ func (r *Repository) FindAll(ctx context.Context, query OperationQuery) ([]*Oper
 		}
 		pipeline = append(pipeline, bson.D{{Key: "$match", Value: bson.D{{Key: "_id", Value: bson.D{{Key: "$in", Value: ids}}}}}})
 	} else if query.PayloadType != nil {
-		r.logger.Info("searching by payloadType")
-		if math.IsNaN(*query.PayloadType) {
-			r.logger.Info("searching by payloadType: payloadType is NaN")
-			return []*OperationDto{}, nil
-		}
 		r.logger.Info("searching by payloadType: calling method findOperationsIdByPayloadType with payload type hardcoded to 1")
-		ids, err := findOperationsIdByPayloadType(ctx, r.db, r.logger, 1)
+		ids, err := findOperationsIdByPayloadType(ctx, r.db, r.logger, *query.PayloadType)
 		r.logger.Info("searching by payloadType: finished method findOperationsIdByPayloadType")
 		if err != nil {
 			r.logger.Info("searching by payloadType: returning err", zap.Error(err))

--- a/api/handlers/operations/repository.go
+++ b/api/handlers/operations/repository.go
@@ -144,22 +144,18 @@ func buildQueryOperationsByAppID(appID string, exclusive bool) bson.D {
 		return bson.D{{Key: "$match", Value: bson.M{}}}
 	}
 
-	var matchingCondition bson.D
-
 	if exclusive {
-		matchingCondition = bson.D{
-			{Key: "$and", Value: bson.A{
-				bson.D{{Key: "rawStandardizedProperties.appIds", Value: bson.M{"$eq": []string{appID}}}},
-				bson.D{{Key: "rawStandardizedProperties.appIds", Value: bson.M{"$size": 1}}},
-				bson.D{{Key: "standardizedProperties.appIds", Value: bson.M{"$eq": []string{appID}}}},
-				bson.D{{Key: "standardizedProperties.appIds", Value: bson.M{"$size": 1}}},
-			}},
-		}
+		return bson.D{{Key: "$match", Value: bson.M{
+			"$and": bson.A{
+				bson.M{"rawStandardizedProperties.appIds": bson.M{"$eq": []string{appID}}},
+				bson.M{"rawStandardizedProperties.appIds": bson.M{"$size": 1}},
+				bson.M{"standardizedProperties.appIds": bson.M{"$eq": []string{appID}}},
+				bson.M{"standardizedProperties.appIds": bson.M{"$size": 1}},
+			}}}}
 	} else {
-		matchingCondition = bson.D{{Key: "rawStandardizedProperties.appIds", Value: bson.M{"$in": []string{appID}}}}
+		return bson.D{{Key: "$match", Value: bson.M{"rawStandardizedProperties.appIds": bson.M{"$in": []string{appID}}}}}
 	}
 
-	return bson.D{{Key: "$match", Value: matchingCondition}}
 }
 
 // findOperationsIdByAddress returns all operations filtered by address.

--- a/api/handlers/operations/repository.go
+++ b/api/handlers/operations/repository.go
@@ -166,7 +166,7 @@ func buildQueryOperationsByAppID(appID string, exclusive bool) bson.D {
 	matchParsedVaa := bson.D{{Key: "$match", Value: bson.D{{Key: "$or", Value: bson.A{
 		bson.D{{Key: "parsedVaa", Value: bson.M{"$elemMatch": bson.M{"appIds": appIdsCondition}}}},
 		bson.D{{Key: "parsedVaa", Value: bson.M{"$elemMatch": bson.M{"rawStandardizedProperties.appIds": appIdsCondition}}}},
-		bson.D{{Key: "standardizedProperties.appIds", Value: appIdsCondition}},
+		bson.D{{Key: "parsedVaa", Value: bson.M{"$elemMatch": bson.M{"standardizedProperties.appIds": appIdsCondition}}}},
 	}}}}}
 
 	return matchParsedVaa

--- a/api/handlers/operations/repository.go
+++ b/api/handlers/operations/repository.go
@@ -147,10 +147,8 @@ func buildQueryOperationsByAppID(appID string, exclusive bool) bson.D {
 	if exclusive {
 		return bson.D{{Key: "$match", Value: bson.M{
 			"$and": bson.A{
-				bson.M{"rawStandardizedProperties.appIds": bson.M{"$eq": []string{appID}}},
+				bson.M{"rawStandardizedProperties.appIds": bson.M{"$in": []string{appID}}},
 				bson.M{"rawStandardizedProperties.appIds": bson.M{"$size": 1}},
-				bson.M{"standardizedProperties.appIds": bson.M{"$eq": []string{appID}}},
-				bson.M{"standardizedProperties.appIds": bson.M{"$size": 1}},
 			}}}}
 	} else {
 		return bson.D{{Key: "$match", Value: bson.M{"rawStandardizedProperties.appIds": bson.M{"$in": []string{appID}}}}}

--- a/api/handlers/operations/repository.go
+++ b/api/handlers/operations/repository.go
@@ -151,6 +151,8 @@ func buildQueryOperationsByAppID(appID string, exclusive bool) bson.D {
 			{Key: "$and", Value: bson.A{
 				bson.D{{Key: "rawStandardizedProperties.appIds", Value: bson.M{"$eq": []string{appID}}}},
 				bson.D{{Key: "rawStandardizedProperties.appIds", Value: bson.M{"$size": 1}}},
+				bson.D{{Key: "standardizedProperties.appIds", Value: bson.M{"$eq": []string{appID}}}},
+				bson.D{{Key: "standardizedProperties.appIds", Value: bson.M{"$size": 1}}},
 			}},
 		}
 	} else {

--- a/api/handlers/operations/repository.go
+++ b/api/handlers/operations/repository.go
@@ -144,16 +144,20 @@ func buildQueryOperationsByAppID(appID string, exclusive bool) bson.D {
 		return bson.D{{Key: "$match", Value: bson.M{}}}
 	}
 
-	var appIdsCondition interface{}
+	var matchingCondition bson.D
+
 	if exclusive {
-		appIdsCondition = bson.M{"$eq": []string{appID}}
+		matchingCondition = bson.D{
+			{Key: "$and", Value: bson.A{
+				bson.D{{Key: "rawStandardizedProperties.appIds", Value: bson.M{"$eq": []string{appID}}}},
+				bson.D{{Key: "rawStandardizedProperties.appIds", Value: bson.M{"$size": 1}}},
+			}},
+		}
 	} else {
-		appIdsCondition = bson.M{"$in": []string{appID}}
+		matchingCondition = bson.D{{Key: "rawStandardizedProperties.appIds", Value: bson.M{"$in": []string{appID}}}}
 	}
 
-	matchParsedVaa := bson.D{{Key: "$match", Value: bson.M{"rawStandardizedProperties.appIds": appIdsCondition}}}
-
-	return matchParsedVaa
+	return bson.D{{Key: "$match", Value: matchingCondition}}
 }
 
 // findOperationsIdByAddress returns all operations filtered by address.

--- a/api/handlers/operations/service.go
+++ b/api/handlers/operations/service.go
@@ -32,9 +32,12 @@ func (s *Service) FindById(ctx context.Context, chainID vaa.ChainID,
 }
 
 type OperationFilter struct {
-	TxHash     *types.TxHash
-	Address    string
-	Pagination pagination.Pagination
+	TxHash      *types.TxHash
+	Address     string
+	ChainID     *vaa.ChainID
+	AppID       string
+	Pagination  pagination.Pagination
+	PayloadType *float64
 }
 
 // FindAll returns all operations filtered by q.
@@ -45,9 +48,12 @@ func (s *Service) FindAll(ctx context.Context, filter OperationFilter) ([]*Opera
 	}
 
 	operationQuery := OperationQuery{
-		TxHash:     txHash,
-		Address:    filter.Address,
-		Pagination: filter.Pagination,
+		TxHash:      txHash,
+		Address:     filter.Address,
+		Pagination:  filter.Pagination,
+		ChainId:     filter.ChainID,
+		AppId:       filter.AppID,
+		PayloadType: filter.PayloadType,
 	}
 
 	operations, err := s.repo.FindAll(ctx, operationQuery)

--- a/api/handlers/operations/service.go
+++ b/api/handlers/operations/service.go
@@ -32,12 +32,15 @@ func (s *Service) FindById(ctx context.Context, chainID vaa.ChainID,
 }
 
 type OperationFilter struct {
-	TxHash      *types.TxHash
-	Address     string
-	ChainID     *vaa.ChainID
-	AppID       string
-	Pagination  pagination.Pagination
-	PayloadType *float64
+	TxHash         *types.TxHash
+	Address        string
+	ChainID        *vaa.ChainID
+	SourceChainID  *vaa.ChainID
+	TargetChainID  *vaa.ChainID
+	AppID          string
+	ExclusiveAppId bool
+	Pagination     pagination.Pagination
+	PayloadType    *float64
 }
 
 // FindAll returns all operations filtered by q.
@@ -48,12 +51,15 @@ func (s *Service) FindAll(ctx context.Context, filter OperationFilter) ([]*Opera
 	}
 
 	operationQuery := OperationQuery{
-		TxHash:      txHash,
-		Address:     filter.Address,
-		Pagination:  filter.Pagination,
-		ChainId:     filter.ChainID,
-		AppId:       filter.AppID,
-		PayloadType: filter.PayloadType,
+		TxHash:         txHash,
+		Address:        filter.Address,
+		Pagination:     filter.Pagination,
+		ChainID:        filter.ChainID,
+		SourceChainID:  filter.SourceChainID,
+		TargetChainID:  filter.TargetChainID,
+		AppID:          filter.AppID,
+		ExclusiveAppId: filter.ExclusiveAppId,
+		PayloadType:    filter.PayloadType,
 	}
 
 	operations, err := s.repo.FindAll(ctx, operationQuery)

--- a/api/handlers/operations/service.go
+++ b/api/handlers/operations/service.go
@@ -58,6 +58,10 @@ func (s *Service) FindAll(ctx context.Context, filter OperationFilter) ([]*Opera
 		ExclusiveAppId: filter.ExclusiveAppId,
 	}
 
+	if operationQuery.AppID != "" || operationQuery.SourceChainID != nil || operationQuery.TargetChainID != nil {
+		return s.repo.FindByChainAndAppId(ctx, operationQuery)
+	}
+
 	operations, err := s.repo.FindAll(ctx, operationQuery)
 	if err != nil {
 		return nil, err

--- a/api/handlers/operations/service.go
+++ b/api/handlers/operations/service.go
@@ -34,13 +34,11 @@ func (s *Service) FindById(ctx context.Context, chainID vaa.ChainID,
 type OperationFilter struct {
 	TxHash         *types.TxHash
 	Address        string
-	ChainID        *vaa.ChainID
 	SourceChainID  *vaa.ChainID
 	TargetChainID  *vaa.ChainID
 	AppID          string
 	ExclusiveAppId bool
 	Pagination     pagination.Pagination
-	PayloadType    *float64
 }
 
 // FindAll returns all operations filtered by q.
@@ -54,12 +52,10 @@ func (s *Service) FindAll(ctx context.Context, filter OperationFilter) ([]*Opera
 		TxHash:         txHash,
 		Address:        filter.Address,
 		Pagination:     filter.Pagination,
-		ChainID:        filter.ChainID,
 		SourceChainID:  filter.SourceChainID,
 		TargetChainID:  filter.TargetChainID,
 		AppID:          filter.AppID,
 		ExclusiveAppId: filter.ExclusiveAppId,
-		PayloadType:    filter.PayloadType,
 	}
 
 	operations, err := s.repo.FindAll(ctx, operationQuery)

--- a/api/main.go
+++ b/api/main.go
@@ -111,7 +111,7 @@ func main() {
 
 	// Setup DB
 	rootLogger.Info("connecting to MongoDB")
-	db, err := dbutil.Connect(appCtx, rootLogger, cfg.DB.URL, cfg.DB.Name, false)
+	db, err := dbutil.Connect(appCtx, rootLogger, cfg.DB.URL, cfg.DB.Name, true)
 	if err != nil {
 		rootLogger.Fatal("failed to connect to MongoDB", zap.Error(err))
 	}

--- a/api/main.go
+++ b/api/main.go
@@ -111,7 +111,7 @@ func main() {
 
 	// Setup DB
 	rootLogger.Info("connecting to MongoDB")
-	db, err := dbutil.Connect(appCtx, rootLogger, cfg.DB.URL, cfg.DB.Name, true)
+	db, err := dbutil.Connect(appCtx, rootLogger, cfg.DB.URL, cfg.DB.Name, false)
 	if err != nil {
 		rootLogger.Fatal("failed to connect to MongoDB", zap.Error(err))
 	}

--- a/api/middleware/extract_parameters.go
+++ b/api/middleware/extract_parameters.go
@@ -61,6 +61,28 @@ func ExtractToChain(c *fiber.Ctx, l *zap.Logger) (*sdk.ChainID, error) {
 	return &result, nil
 }
 
+func ExtractChain(c *fiber.Ctx, l *zap.Logger) (*sdk.ChainID, error) {
+
+	param := c.Query("chain")
+	if param == "" {
+		return nil, nil
+	}
+
+	chain, err := strconv.ParseInt(param, 10, 16)
+	if err != nil {
+		requestID := fmt.Sprintf("%v", c.Locals("requestid"))
+		l.Error("failed to parse toChain parameter",
+			zap.Error(err),
+			zap.String("requestID", requestID),
+		)
+
+		return nil, response.NewInvalidParamError(c, "INVALID CHAIN VALUE", errors.WithStack(err))
+	}
+
+	result := sdk.ChainID(chain)
+	return &result, nil
+}
+
 // ExtractEmitterAddr parses the emitter address from the request path.
 //
 // When the parameter `chainIdHint` is not nil, this function will attempt to parse the
@@ -255,6 +277,24 @@ func ExtractParsedPayload(c *fiber.Ctx, l *zap.Logger) (bool, error) {
 
 func ExtractAppId(c *fiber.Ctx, l *zap.Logger) string {
 	return c.Query("appId")
+}
+
+func ExtractPayloadType(c *fiber.Ctx, l *zap.Logger) (*float64, error) {
+	payloadTypeParam := c.Query("payloadType")
+	if payloadTypeParam == "" {
+		return nil, nil
+	}
+
+	payloadType, err := strconv.ParseFloat(payloadTypeParam, 64)
+	if err != nil {
+		requestID := fmt.Sprintf("%v", c.Locals("requestid"))
+		l.Error("failed to parse payload type parameter",
+			zap.Error(err),
+			zap.String("requestID", requestID),
+		)
+		return nil, response.NewInvalidParamError(c, "INVALID PAYLOAD TYPE", errors.WithStack(err))
+	}
+	return &payloadType, nil
 }
 
 func ExtractTimeSpan(c *fiber.Ctx, l *zap.Logger) (string, error) {

--- a/api/middleware/extract_parameters.go
+++ b/api/middleware/extract_parameters.go
@@ -62,8 +62,20 @@ func ExtractToChain(c *fiber.Ctx, l *zap.Logger) (*sdk.ChainID, error) {
 }
 
 func ExtractChain(c *fiber.Ctx, l *zap.Logger) (*sdk.ChainID, error) {
+	return extractChainQueryParam(c, l, "chain")
+}
 
-	param := c.Query("chain")
+func ExtractSourceChain(c *fiber.Ctx, l *zap.Logger) (*sdk.ChainID, error) {
+	return extractChainQueryParam(c, l, "sourceChain")
+}
+
+func ExtractTargetChain(c *fiber.Ctx, l *zap.Logger) (*sdk.ChainID, error) {
+	return extractChainQueryParam(c, l, "targetChain")
+}
+
+func extractChainQueryParam(c *fiber.Ctx, l *zap.Logger, queryParam string) (*sdk.ChainID, error) {
+
+	param := c.Query(queryParam)
 	if param == "" {
 		return nil, nil
 	}
@@ -277,6 +289,14 @@ func ExtractParsedPayload(c *fiber.Ctx, l *zap.Logger) (bool, error) {
 
 func ExtractAppId(c *fiber.Ctx, l *zap.Logger) string {
 	return c.Query("appId")
+}
+
+func ExtractExclusiveAppId(c *fiber.Ctx, l *zap.Logger) (bool, error) {
+	query := c.Query("exclusiveAppId")
+	if query == "" {
+		return false, nil
+	}
+	return strconv.ParseBool(query)
 }
 
 func ExtractPayloadType(c *fiber.Ctx, l *zap.Logger) (*float64, error) {

--- a/api/middleware/extract_parameters.go
+++ b/api/middleware/extract_parameters.go
@@ -299,24 +299,6 @@ func ExtractExclusiveAppId(c *fiber.Ctx, l *zap.Logger) (bool, error) {
 	return strconv.ParseBool(query)
 }
 
-func ExtractPayloadType(c *fiber.Ctx, l *zap.Logger) (*float64, error) {
-	payloadTypeParam := c.Query("payloadType")
-	if payloadTypeParam == "" {
-		return nil, nil
-	}
-
-	payloadType, err := strconv.ParseFloat(payloadTypeParam, 64)
-	if err != nil {
-		requestID := fmt.Sprintf("%v", c.Locals("requestid"))
-		l.Error("failed to parse payload type parameter",
-			zap.Error(err),
-			zap.String("requestID", requestID),
-		)
-		return nil, response.NewInvalidParamError(c, "INVALID PAYLOAD TYPE", errors.WithStack(err))
-	}
-	return &payloadType, nil
-}
-
 func ExtractTimeSpan(c *fiber.Ctx, l *zap.Logger) (string, error) {
 	// get the timeSpan from query params
 	timeSpanStr := c.Query("timeSpan", "1d")

--- a/api/middleware/extract_parameters.go
+++ b/api/middleware/extract_parameters.go
@@ -291,7 +291,7 @@ func ExtractAppId(c *fiber.Ctx, l *zap.Logger) string {
 	return c.Query("appId")
 }
 
-func ExtractExclusiveAppId(c *fiber.Ctx, l *zap.Logger) (bool, error) {
+func ExtractExclusiveAppId(c *fiber.Ctx) (bool, error) {
 	query := c.Query("exclusiveAppId")
 	if query == "" {
 		return false, nil

--- a/api/routes/wormscan/operations/controller.go
+++ b/api/routes/wormscan/operations/controller.go
@@ -59,7 +59,21 @@ func (c *Controller) FindAll(ctx *fiber.Ctx) error {
 		return err
 	}
 
+	sourceChainID, err := middleware.ExtractSourceChain(ctx, c.logger)
+	if err != nil {
+		return err
+	}
+
+	targeChainID, err := middleware.ExtractTargetChain(ctx, c.logger)
+	if err != nil {
+		return err
+	}
+
 	appID := middleware.ExtractAppId(ctx, c.logger)
+	exclusiveAppId, err := middleware.ExtractExclusiveAppId(ctx, c.logger)
+	if err != nil {
+		return err
+	}
 
 	payloadType, err := middleware.ExtractPayloadType(ctx, c.logger)
 	if err != nil {
@@ -69,9 +83,11 @@ func (c *Controller) FindAll(ctx *fiber.Ctx) error {
 	searchByAddress := address != ""
 	searchByTxHash := txHash != nil && txHash.String() != ""
 	searchByChainId := chainID != nil
+	searchBySourceChain := sourceChainID != nil
+	searchByTargetChain := targeChainID != nil
 	searchByAppID := len(appID) > 0
 	searchByPayloadType := payloadType != nil
-	searchCriteria := []bool{searchByAddress, searchByTxHash, searchByChainId, searchByAppID, searchByPayloadType}
+	searchCriteria := []bool{searchByAddress, searchByTxHash, searchByChainId, searchByAppID, searchByPayloadType, searchBySourceChain, searchByTargetChain}
 
 	searchCriteriaCount := 0
 	for _, sc := range searchCriteria {
@@ -84,12 +100,15 @@ func (c *Controller) FindAll(ctx *fiber.Ctx) error {
 	}
 
 	filter := operations.OperationFilter{
-		TxHash:      txHash,
-		Address:     address,
-		ChainID:     chainID,
-		AppID:       appID,
-		Pagination:  *pagination,
-		PayloadType: payloadType,
+		TxHash:         txHash,
+		Address:        address,
+		ChainID:        chainID,
+		SourceChainID:  sourceChainID,
+		TargetChainID:  targeChainID,
+		AppID:          appID,
+		ExclusiveAppId: exclusiveAppId,
+		Pagination:     *pagination,
+		PayloadType:    payloadType,
 	}
 
 	// Find operations by q search param.

--- a/api/routes/wormscan/operations/controller.go
+++ b/api/routes/wormscan/operations/controller.go
@@ -83,11 +83,10 @@ func (c *Controller) FindAll(ctx *fiber.Ctx) error {
 	searchByAddress := address != ""
 	searchByTxHash := txHash != nil && txHash.String() != ""
 	searchByChainId := chainID != nil
-	searchBySourceChain := sourceChainID != nil
-	searchByTargetChain := targeChainID != nil
+	searchBySourceAndTargetChain := sourceChainID != nil && targeChainID != nil
 	searchByAppID := len(appID) > 0
 	searchByPayloadType := payloadType != nil
-	searchCriteria := []bool{searchByAddress, searchByTxHash, searchByChainId, searchByAppID, searchByPayloadType, searchBySourceChain, searchByTargetChain}
+	searchCriteria := []bool{searchByAddress, searchByTxHash, searchByChainId, searchByAppID, searchByPayloadType, searchBySourceAndTargetChain}
 
 	searchCriteriaCount := 0
 	for _, sc := range searchCriteria {

--- a/api/routes/wormscan/operations/controller.go
+++ b/api/routes/wormscan/operations/controller.go
@@ -72,7 +72,7 @@ func (c *Controller) FindAll(ctx *fiber.Ctx) error {
 	}
 
 	appID := middleware.ExtractAppId(ctx, c.logger)
-	exclusiveAppId, err := middleware.ExtractExclusiveAppId(ctx, c.logger)
+	exclusiveAppId, err := middleware.ExtractExclusiveAppId(ctx)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- Issue: #1220 
- Add filters to `/operations` endpoint:
  - `sourceChain` and `targetChain` : filter by chain individually or in combination.
  - `appId` and `exclusiveAppId`: filter by appId and use exclusiveAppId for filtering VAA with only that appId

### Examples:
- `/operations?sourceChain=3&targetChain=3` : filter operations that have `sourceChain` 3 **or** have `targetChain` 3.
- `/operations?sourceChain=3&targetChain=4` : filter operations that have `sourceChain` 3 **and** have `targetChain` 4.
- `/operations?sourceChain=3` : filter operations with `sourceChain` 3.
- `/operations?targetChain=3` : filter operations with `targetChain` 3.
- `/operations?appId=CCTP_WORMHOLE_INTEGRATION` : filter operations that **contain** in `appIds` _CCTP_WORMHOLE_INTEGRATION_.
- `/operations?appId=CCTP_WORMHOLE_INTEGRATION&exclusiveAppId=true` : filter operations that have **exactly**  appIds = ["_CCTP_WORMHOLE_INTEGRATION_"]
