### PR TITLE
[Blockchain Watcher] (FIX - SUI) Fix currentCheckpoint value for report metrics on grafana

### DIFF
--- a/blockchain-watcher/src/domain/actions/sui/PollSuiTransactions.ts
+++ b/blockchain-watcher/src/domain/actions/sui/PollSuiTransactions.ts
@@ -75,6 +75,7 @@ export class PollSuiTransactions extends RunPollingJob {
       `[sui][PollSuiTransactions] Got ${txs.length} txs from ${this.cursor.checkpoint} to ${newCursor.checkpoint}`
     );
 
+    this.currentCheckpoint = this.cursor.checkpoint;
     this.cursor = newCursor;
 
     return txs;


### PR DESCRIPTION
## Link Issue

## Description
- Fix currentCheckpoint value for report metrics on grafana

## Test or Screenshots
**_Error_**

<img width="365" alt="image" src="https://github.com/wormhole-foundation/wormhole-explorer/assets/52217955/0e5702c0-ff8d-4d27-9c25-1310766b24b9">

We dont have mapping the current position for the cursor on PollSuiTransactions


