### PR TITLE
[WORMSCAN-API-1335] Support querying with multiple sourceChains and targetChains

### DIFF
--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -915,13 +915,13 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "source chain of the operation",
+                        "description": "source chains of the operation, separated by comma",
                         "name": "sourceChain",
                         "in": "query"
                     },
                     {
                         "type": "string",
-                        "description": "target chain of the operation",
+                        "description": "target chains of the operation, separated by comma",
                         "name": "targetChain",
                         "in": "query"
                     },
@@ -1762,7 +1762,7 @@ const docTemplate = `{
         },
         "/api/v1/x-chain-activity/tops": {
             "get": {
-                "description": "Search, for a specific period of time, the number of transactions and the volume.",
+                "description": "Search for a specific period of time the number of transactions and the volume.",
                 "tags": [
                     "wormholescan"
                 ],
@@ -2741,17 +2741,17 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "sourceChain": {
-                    "$ref": "#/definitions/operations.SourceChains"
+                    "$ref": "#/definitions/operations.SourceChain"
                 },
                 "targetChain": {
-                    "$ref": "#/definitions/operations.TargetChains"
+                    "$ref": "#/definitions/operations.TargetChain"
                 },
                 "vaa": {
                     "$ref": "#/definitions/operations.Vaa"
                 }
             }
         },
-        "operations.SourceChains": {
+        "operations.SourceChain": {
             "type": "object",
             "properties": {
                 "attribute": {
@@ -2815,7 +2815,7 @@ const docTemplate = `{
                 }
             }
         },
-        "operations.TargetChains": {
+        "operations.TargetChain": {
             "type": "object",
             "properties": {
                 "chainId": {

--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -2741,17 +2741,17 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "sourceChain": {
-                    "$ref": "#/definitions/operations.SourceChain"
+                    "$ref": "#/definitions/operations.SourceChains"
                 },
                 "targetChain": {
-                    "$ref": "#/definitions/operations.TargetChain"
+                    "$ref": "#/definitions/operations.TargetChains"
                 },
                 "vaa": {
                     "$ref": "#/definitions/operations.Vaa"
                 }
             }
         },
-        "operations.SourceChain": {
+        "operations.SourceChains": {
             "type": "object",
             "properties": {
                 "attribute": {
@@ -2815,7 +2815,7 @@ const docTemplate = `{
                 }
             }
         },
-        "operations.TargetChain": {
+        "operations.TargetChains": {
             "type": "object",
             "properties": {
                 "chainId": {

--- a/api/docs/swagger.json
+++ b/api/docs/swagger.json
@@ -908,13 +908,13 @@
                     },
                     {
                         "type": "string",
-                        "description": "source chain of the operation",
+                        "description": "source chains of the operation, separated by comma",
                         "name": "sourceChain",
                         "in": "query"
                     },
                     {
                         "type": "string",
-                        "description": "target chain of the operation",
+                        "description": "target chains of the operation, separated by comma",
                         "name": "targetChain",
                         "in": "query"
                     },
@@ -1755,7 +1755,7 @@
         },
         "/api/v1/x-chain-activity/tops": {
             "get": {
-                "description": "Search, for a specific period of time, the number of transactions and the volume.",
+                "description": "Search for a specific period of time the number of transactions and the volume.",
                 "tags": [
                     "wormholescan"
                 ],

--- a/api/docs/swagger.yaml
+++ b/api/docs/swagger.yaml
@@ -1782,11 +1782,11 @@ paths:
         in: query
         name: pageSize
         type: integer
-      - description: source chain of the operation
+      - description: source chains of the operation, separated by comma
         in: query
         name: sourceChain
         type: string
-      - description: target chain of the operation
+      - description: target chains of the operation, separated by comma
         in: query
         name: targetChain
         type: string
@@ -2363,7 +2363,7 @@ paths:
       - wormholescan
   /api/v1/x-chain-activity/tops:
     get:
-      description: Search, for a specific period of time, the number of transactions
+      description: Search for a specific period of time the number of transactions
         and the volume.
       operationId: x-chain-activity-tops
       parameters:

--- a/api/handlers/operations/repository.go
+++ b/api/handlers/operations/repository.go
@@ -231,7 +231,7 @@ func (r *Repository) FindByChainAndAppId(ctx context.Context, query OperationQue
 
 	var pipeline mongo.Pipeline
 
-	if len(query.SourceChainIDs) != 0 || len(query.TargetChainIDs) != 0 {
+	if len(query.SourceChainIDs) > 0 || len(query.TargetChainIDs) > 0 {
 		matchBySourceTargetChain := buildQueryOperationsByChain(query.SourceChainIDs, query.TargetChainIDs)
 		pipeline = append(pipeline, matchBySourceTargetChain)
 	}

--- a/api/handlers/operations/repository_test.go
+++ b/api/handlers/operations/repository_test.go
@@ -1,0 +1,235 @@
+package operations_test
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/wormhole-foundation/wormhole-explorer/api/handlers/operations"
+	sdk "github.com/wormhole-foundation/wormhole/sdk/vaa"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"testing"
+)
+
+var sortStage = bson.D{{"$sort", bson.D{{"timestamp", -1}, {"_id", -1}}}}
+var skipStage = bson.D{{"$skip", int64(0)}}
+var limitStage = bson.D{{"$limit", int64(0)}}
+var lookupVaasStage = bson.D{
+	{"$lookup", bson.D{
+		{"from", "vaas"},
+		{"localField", "_id"},
+		{"foreignField", "_id"},
+		{"as", "vaas"}}}}
+var lookupTransferPricesStage = bson.D{{"$lookup", bson.D{
+	{"from", "transferPrices"},
+	{"localField", "_id"},
+	{"foreignField", "_id"},
+	{"as", "transferPrices"},
+}}}
+var lookupGlobalTransactionsStage = bson.D{{"$lookup", bson.D{
+	{"from", "globalTransactions"},
+	{"localField", "_id"},
+	{"foreignField", "_id"},
+	{"as", "globalTransactions"},
+}}}
+var addFieldsStage = bson.D{{"$addFields", bson.D{
+	{"payload", "$parsedPayload"},
+	{"vaa", bson.D{{"$arrayElemAt", bson.A{"$vaas", 0}}}},
+	{"symbol", bson.D{{"$arrayElemAt", bson.A{"$transferPrices.symbol", 0}}}},
+	{"usdAmount", bson.D{{"$arrayElemAt", bson.A{"$transferPrices.usdAmount", 0}}}},
+	{"tokenAmount", bson.D{{"$arrayElemAt", bson.A{"$transferPrices.tokenAmount", 0}}}},
+	{"originTx", bson.D{{"$arrayElemAt", bson.A{"$globalTransactions.originTx", 0}}}},
+	{"destinationTx", bson.D{{"$arrayElemAt", bson.A{"$globalTransactions.destinationTx", 0}}}},
+}}}
+var unSetStage = bson.D{{"$unset", bson.A{"transferPrices"}}}
+
+func TestPipeline_FindByChainAndAppId(t *testing.T) {
+	cases := []struct {
+		name     string
+		query    operations.OperationQuery
+		expected mongo.Pipeline
+	}{
+		{
+			name:  "Search with no query filters",
+			query: operations.OperationQuery{},
+			expected: mongo.Pipeline{
+				sortStage,
+				skipStage,
+				limitStage,
+				lookupVaasStage,
+				lookupTransferPricesStage,
+				lookupGlobalTransactionsStage,
+				addFieldsStage,
+				unSetStage,
+			},
+		},
+		{
+			name: "Search with single source_chain ",
+			query: operations.OperationQuery{
+				SourceChainIDs: []sdk.ChainID{1},
+			},
+			expected: mongo.Pipeline{
+				bson.D{{"$match", bson.M{"$and": bson.A{
+					bson.M{"rawStandardizedProperties.fromChain": bson.M{"$in": []sdk.ChainID{1}}},
+				}}}},
+				sortStage,
+				skipStage,
+				limitStage,
+				lookupVaasStage,
+				lookupTransferPricesStage,
+				lookupGlobalTransactionsStage,
+				addFieldsStage,
+				unSetStage,
+			},
+		},
+		{
+			name: "Search with multiple source_chain ",
+			query: operations.OperationQuery{
+				SourceChainIDs: []sdk.ChainID{1, 2},
+			},
+			expected: mongo.Pipeline{
+				bson.D{{"$match", bson.M{"$and": bson.A{
+					bson.M{"rawStandardizedProperties.fromChain": bson.M{"$in": []sdk.ChainID{1, 2}}},
+				}}}},
+				sortStage,
+				skipStage,
+				limitStage,
+				lookupVaasStage,
+				lookupTransferPricesStage,
+				lookupGlobalTransactionsStage,
+				addFieldsStage,
+				unSetStage,
+			},
+		},
+		{
+			name: "Search with single target_chain ",
+			query: operations.OperationQuery{
+				TargetChainIDs: []sdk.ChainID{1},
+			},
+			expected: mongo.Pipeline{
+				bson.D{{"$match", bson.M{"$and": bson.A{
+					bson.M{"rawStandardizedProperties.toChain": bson.M{"$in": []sdk.ChainID{1}}},
+				}}}},
+				sortStage,
+				skipStage,
+				limitStage,
+				lookupVaasStage,
+				lookupTransferPricesStage,
+				lookupGlobalTransactionsStage,
+				addFieldsStage,
+				unSetStage,
+			},
+		},
+		{
+			name: "Search with single target_chain ",
+			query: operations.OperationQuery{
+				TargetChainIDs: []sdk.ChainID{1, 2},
+			},
+			expected: mongo.Pipeline{
+				bson.D{{"$match", bson.M{"$and": bson.A{
+					bson.M{"rawStandardizedProperties.toChain": bson.M{"$in": []sdk.ChainID{1, 2}}},
+				}}}},
+				sortStage,
+				skipStage,
+				limitStage,
+				lookupVaasStage,
+				lookupTransferPricesStage,
+				lookupGlobalTransactionsStage,
+				addFieldsStage,
+				unSetStage,
+			},
+		},
+		{
+			name: "Search with same source and target chain",
+			query: operations.OperationQuery{
+				SourceChainIDs: []sdk.ChainID{1},
+				TargetChainIDs: []sdk.ChainID{1},
+			},
+			expected: mongo.Pipeline{
+				bson.D{{"$match", bson.M{"$or": bson.A{
+					bson.M{"rawStandardizedProperties.fromChain": bson.M{"$in": []sdk.ChainID{1}}},
+					bson.M{"rawStandardizedProperties.toChain": bson.M{"$in": []sdk.ChainID{1}}},
+				}}}},
+				sortStage,
+				skipStage,
+				limitStage,
+				lookupVaasStage,
+				lookupTransferPricesStage,
+				lookupGlobalTransactionsStage,
+				addFieldsStage,
+				unSetStage,
+			},
+		},
+		{
+			name: "Search with different source and target chain",
+			query: operations.OperationQuery{
+				SourceChainIDs: []sdk.ChainID{1},
+				TargetChainIDs: []sdk.ChainID{2},
+			},
+			expected: mongo.Pipeline{
+				bson.D{{"$match", bson.M{"$and": bson.A{
+					bson.M{"rawStandardizedProperties.fromChain": bson.M{"$in": []sdk.ChainID{1}}},
+					bson.M{"rawStandardizedProperties.toChain": bson.M{"$in": []sdk.ChainID{2}}},
+				}}}},
+				sortStage,
+				skipStage,
+				limitStage,
+				lookupVaasStage,
+				lookupTransferPricesStage,
+				lookupGlobalTransactionsStage,
+				addFieldsStage,
+				unSetStage,
+			},
+		},
+		{
+			name: "Search by appID exclusive",
+			query: operations.OperationQuery{
+				AppIDs:         []string{"CCTP_WORMHOLE_INTEGRATION", "PORTAL_TOKEN_BRIDGE"},
+				ExclusiveAppId: true,
+			},
+			expected: mongo.Pipeline{
+				bson.D{{"$match", bson.M{"$or": bson.A{
+					bson.M{"$and": bson.A{
+						bson.M{"rawStandardizedProperties.appIds": bson.M{"$eq": "CCTP_WORMHOLE_INTEGRATION"}},
+						bson.M{"rawStandardizedProperties.appIds": bson.M{"$size": 1}},
+					}},
+					bson.M{"$and": bson.A{
+						bson.M{"rawStandardizedProperties.appIds": bson.M{"$eq": "PORTAL_TOKEN_BRIDGE"}},
+						bson.M{"rawStandardizedProperties.appIds": bson.M{"$size": 1}},
+					}},
+				}}}},
+				sortStage,
+				skipStage,
+				limitStage,
+				lookupVaasStage,
+				lookupTransferPricesStage,
+				lookupGlobalTransactionsStage,
+				addFieldsStage,
+				unSetStage,
+			},
+		},
+		{
+			name: "Search by appID exclusive false",
+			query: operations.OperationQuery{
+				AppIDs:         []string{"CCTP_WORMHOLE_INTEGRATION", "PORTAL_TOKEN_BRIDGE"},
+				ExclusiveAppId: false,
+			},
+			expected: mongo.Pipeline{
+				bson.D{{"$match", bson.M{"rawStandardizedProperties.appIds": bson.M{"$in": []string{"CCTP_WORMHOLE_INTEGRATION", "PORTAL_TOKEN_BRIDGE"}}}}},
+				sortStage,
+				skipStage,
+				limitStage,
+				lookupVaasStage,
+				lookupTransferPricesStage,
+				lookupGlobalTransactionsStage,
+				addFieldsStage,
+				unSetStage,
+			},
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			result := operations.BuildPipelineSearchByChainAndAppID(testCase.query)
+			assert.Equal(t, testCase.expected, result, "Expected pipeline did not match actual pipeline")
+		})
+	}
+}

--- a/api/handlers/operations/repository_test.go
+++ b/api/handlers/operations/repository_test.go
@@ -62,7 +62,7 @@ func TestPipeline_FindByChainAndAppId(t *testing.T) {
 			},
 		},
 		{
-			name: "Search with single source_chain ",
+			name: "Search with single source_chain",
 			query: operations.OperationQuery{
 				SourceChainIDs: []sdk.ChainID{1},
 			},
@@ -81,7 +81,7 @@ func TestPipeline_FindByChainAndAppId(t *testing.T) {
 			},
 		},
 		{
-			name: "Search with multiple source_chain ",
+			name: "Search with multiple source_chain",
 			query: operations.OperationQuery{
 				SourceChainIDs: []sdk.ChainID{1, 2},
 			},
@@ -100,7 +100,7 @@ func TestPipeline_FindByChainAndAppId(t *testing.T) {
 			},
 		},
 		{
-			name: "Search with single target_chain ",
+			name: "Search with single target_chain",
 			query: operations.OperationQuery{
 				TargetChainIDs: []sdk.ChainID{1},
 			},
@@ -119,7 +119,7 @@ func TestPipeline_FindByChainAndAppId(t *testing.T) {
 			},
 		},
 		{
-			name: "Search with single target_chain ",
+			name: "Search with multiple target_chain",
 			query: operations.OperationQuery{
 				TargetChainIDs: []sdk.ChainID{1, 2},
 			},

--- a/api/handlers/operations/service.go
+++ b/api/handlers/operations/service.go
@@ -34,9 +34,9 @@ func (s *Service) FindById(ctx context.Context, chainID vaa.ChainID,
 type OperationFilter struct {
 	TxHash         *types.TxHash
 	Address        string
-	SourceChainID  *vaa.ChainID
-	TargetChainID  *vaa.ChainID
-	AppID          string
+	SourceChainIDs []vaa.ChainID
+	TargetChainIDs []vaa.ChainID
+	AppID          []string
 	ExclusiveAppId bool
 	Pagination     pagination.Pagination
 }
@@ -52,13 +52,13 @@ func (s *Service) FindAll(ctx context.Context, filter OperationFilter) ([]*Opera
 		TxHash:         txHash,
 		Address:        filter.Address,
 		Pagination:     filter.Pagination,
-		SourceChainID:  filter.SourceChainID,
-		TargetChainID:  filter.TargetChainID,
+		SourceChainIDs: filter.SourceChainIDs,
+		TargetChainIDs: filter.TargetChainIDs,
 		AppID:          filter.AppID,
 		ExclusiveAppId: filter.ExclusiveAppId,
 	}
 
-	if operationQuery.AppID != "" || operationQuery.SourceChainID != nil || operationQuery.TargetChainID != nil {
+	if len(operationQuery.AppID) != 0 || len(operationQuery.SourceChainIDs) > 0 || len(operationQuery.TargetChainIDs) > 0 {
 		return s.repo.FindByChainAndAppId(ctx, operationQuery)
 	}
 

--- a/api/handlers/operations/service.go
+++ b/api/handlers/operations/service.go
@@ -36,7 +36,7 @@ type OperationFilter struct {
 	Address        string
 	SourceChainIDs []vaa.ChainID
 	TargetChainIDs []vaa.ChainID
-	AppID          []string
+	AppIDs         []string
 	ExclusiveAppId bool
 	Pagination     pagination.Pagination
 }
@@ -54,11 +54,11 @@ func (s *Service) FindAll(ctx context.Context, filter OperationFilter) ([]*Opera
 		Pagination:     filter.Pagination,
 		SourceChainIDs: filter.SourceChainIDs,
 		TargetChainIDs: filter.TargetChainIDs,
-		AppID:          filter.AppID,
+		AppIDs:         filter.AppIDs,
 		ExclusiveAppId: filter.ExclusiveAppId,
 	}
 
-	if len(operationQuery.AppID) != 0 || len(operationQuery.SourceChainIDs) > 0 || len(operationQuery.TargetChainIDs) > 0 {
+	if len(operationQuery.AppIDs) != 0 || len(operationQuery.SourceChainIDs) > 0 || len(operationQuery.TargetChainIDs) > 0 {
 		return s.repo.FindByChainAndAppId(ctx, operationQuery)
 	}
 

--- a/api/handlers/transactions/model.go
+++ b/api/handlers/transactions/model.go
@@ -215,12 +215,12 @@ type TransactionDto struct {
 }
 
 type ChainActivityTopsQuery struct {
-	SourceChain []sdk.ChainID `json:"source_chain"`
-	TargetChain []sdk.ChainID `json:"target_chain"`
-	AppId       string        `json:"app_id"`
-	From        time.Time     `json:"from"`
-	To          time.Time     `json:"to"`
-	Timespan    Timespan      `json:"timespan"`
+	SourceChains []sdk.ChainID `json:"source_chain"`
+	TargetChains []sdk.ChainID `json:"target_chain"`
+	AppId        string        `json:"app_id"`
+	From         time.Time     `json:"from"`
+	To           time.Time     `json:"to"`
+	Timespan     Timespan      `json:"timespan"`
 }
 
 type Timespan string

--- a/api/handlers/transactions/model.go
+++ b/api/handlers/transactions/model.go
@@ -215,12 +215,12 @@ type TransactionDto struct {
 }
 
 type ChainActivityTopsQuery struct {
-	SourceChain *sdk.ChainID `json:"source_chain"`
-	TargetChain *sdk.ChainID `json:"target_chain"`
-	AppId       string       `json:"app_id"`
-	From        time.Time    `json:"from"`
-	To          time.Time    `json:"to"`
-	Timespan    Timespan     `json:"timespan"`
+	SourceChain []sdk.ChainID `json:"source_chain"`
+	TargetChain []sdk.ChainID `json:"target_chain"`
+	AppId       string        `json:"app_id"`
+	From        time.Time     `json:"from"`
+	To          time.Time     `json:"to"`
+	Timespan    Timespan      `json:"timespan"`
 }
 
 type Timespan string

--- a/api/handlers/transactions/repository.go
+++ b/api/handlers/transactions/repository.go
@@ -1099,9 +1099,9 @@ func (r *Repository) buildChainActivityQueryTops(q ChainActivityTopsQuery) strin
 		val := fmt.Sprintf("r.destination_chain == \"%d\"", q.TargetChains[0])
 		buff := ""
 		for _, tc := range q.TargetChains[1:] {
-			buff += fmt.Sprintf("or r.destination_chain == \"%d\" ", tc)
+			buff += fmt.Sprintf(" or r.destination_chain == \"%d\"", tc)
 		}
-		filterTargetChain = fmt.Sprintf("|> filter(fn: (r) => %s %s)", val, buff)
+		filterTargetChain = fmt.Sprintf("|> filter(fn: (r) => %s%s)", val, buff)
 	}
 
 	filterSourceChain := ""
@@ -1109,9 +1109,9 @@ func (r *Repository) buildChainActivityQueryTops(q ChainActivityTopsQuery) strin
 		val := fmt.Sprintf("r.emitter_chain == \"%d\"", q.SourceChains[0])
 		buff := ""
 		for _, tc := range q.SourceChains[1:] {
-			buff += fmt.Sprintf("or r.emitter_chain == \"%d\" ", tc)
+			buff += fmt.Sprintf(" or r.emitter_chain == \"%d\"", tc)
 		}
-		filterSourceChain = fmt.Sprintf("|> filter(fn: (r) => %s %s)", val, buff)
+		filterSourceChain = fmt.Sprintf("|> filter(fn: (r) => %s%s)", val, buff)
 	}
 
 	filterAppId := ""
@@ -1152,12 +1152,11 @@ func (r *Repository) buildQueryChainActivityTopsByEmitter(q ChainActivityTopsQue
 					import "date"
 
 					from(bucket: "%s")
-		  			|> range(start: %s,stop: %s)
-		  			|> filter(fn: (r) => r._measurement == "%s")
+					|> range(start: %s,stop: %s)
+					|> filter(fn: (r) => r._measurement == "%s")
 					%s
 					|> pivot(rowKey:["_time","emitter_chain"], columnKey: ["_field"], valueColumn: "_value")
-					|> sort(columns:["emitter_chain","_time"],desc:false)
-				`
+					|> sort(columns:["emitter_chain","_time"],desc:false)`
 		return fmt.Sprintf(query, r.bucketInfiniteRetention, start, stop, measurement, filterSourceChain)
 	}
 
@@ -1167,8 +1166,8 @@ func (r *Repository) buildQueryChainActivityTopsByEmitter(q ChainActivityTopsQue
 				import "join"
 
 				data = from(bucket: "%s")
-		  				|> range(start: %s,stop: %s)
-		  				|> filter(fn: (r) => r._measurement == "%s")
+						|> range(start: %s,stop: %s)
+						|> filter(fn: (r) => r._measurement == "%s")
 						%s
 						|> drop(columns:["to"])
 						|> window(every: 1mo, period:1mo)
@@ -1176,7 +1175,7 @@ func (r *Repository) buildQueryChainActivityTopsByEmitter(q ChainActivityTopsQue
 						|> rename(columns: {_start: "_time"})
 						|> map(fn: (r) => ({r with to: string(v: r._stop)}))
 
-				vols = data		
+				vols = data
 						|> filter(fn: (r) => (r._field == "volume" and r._value > 0))
 						|> group(columns:["_time","to","emitter_chain"])
 						|> sum()
@@ -1189,14 +1188,13 @@ func (r *Repository) buildQueryChainActivityTopsByEmitter(q ChainActivityTopsQue
 						|> rename(columns: {_value: "count"})
 
 				join.inner(
-					    left: vols,
-					    right: counts,
-					    on: (l, r) => l._time == r._time and l.emitter_chain == r.emitter_chain,
-					    as: (l, r) => ({l with count: r.count}),
+						left: vols,
+						right: counts,
+						on: (l, r) => l._time == r._time and l.emitter_chain == r.emitter_chain,
+						as: (l, r) => ({l with count: r.count}),
 				)
 				|> group()
-				|> sort(columns:["emitter_chain","_time"],desc:false)
-				`
+				|> sort(columns:["emitter_chain","_time"],desc:false)`
 		return fmt.Sprintf(query, r.bucketInfiniteRetention, start, stop, measurement, filterSourceChain)
 	}
 
@@ -1205,8 +1203,8 @@ func (r *Repository) buildQueryChainActivityTopsByEmitter(q ChainActivityTopsQue
 				import "join"
 
 				data = from(bucket: "%s")
-		  				|> range(start: %s,stop: %s)
-		  				|> filter(fn: (r) => r._measurement == "%s")
+						|> range(start: %s,stop: %s)
+						|> filter(fn: (r) => r._measurement == "%s")
 						%s
 						|> drop(columns:["to"])
 						|> window(every: 1y, period:1y)
@@ -1226,14 +1224,13 @@ func (r *Repository) buildQueryChainActivityTopsByEmitter(q ChainActivityTopsQue
 						|> rename(columns: {_value: "count"})
 
 				join.inner(
-					    left: vols,
-					    right: counts,
-					    on: (l, r) => l._time == r._time and l.emitter_chain == r.emitter_chain,
-					    as: (l, r) => ({l with count: r.count}),
+						left: vols,
+						right: counts,
+						on: (l, r) => l._time == r._time and l.emitter_chain == r.emitter_chain,
+						as: (l, r) => ({l with count: r.count}),
 				)
 				|> group()
-				|> sort(columns:["emitter_chain","_time"],desc:false)
-		`
+				|> sort(columns:["emitter_chain","_time"],desc:false)`
 	return fmt.Sprintf(query, r.bucketInfiniteRetention, start, stop, measurement, filterSourceChain)
 
 }
@@ -1270,8 +1267,7 @@ func (r *Repository) buildQueryChainActivityHourly(start, stop, filterSourceChai
 					    as: (l, r) => ({l with count: r.count}),
 					)
 					|> group()
-					|> sort(columns:["emitter_chain","_time"],desc:false)
-				`
+					|> sort(columns:["emitter_chain","_time"],desc:false)`
 	return fmt.Sprintf(query, r.bucketInfiniteRetention, start, stop, filterSourceChain, filterTargetChain, filterAppId)
 }
 
@@ -1308,8 +1304,7 @@ func (r *Repository) buildQueryChainActivityDaily(start, stop, filterSourceChain
 					    as: (l, r) => ({l with count: r.count}),
 					)
 					|> group()
-					|> sort(columns:["emitter_chain","_time"],desc:false)
-				`
+					|> sort(columns:["emitter_chain","_time"],desc:false)`
 	return fmt.Sprintf(query, r.bucketInfiniteRetention, start, stop, filterSourceChain, filterTargetChain, filterAppId)
 }
 
@@ -1319,8 +1314,8 @@ func (r *Repository) buildQueryChainActivityMonthly(start, stop, filterSourceCha
 				import "join"
 
 				data = from(bucket: "%s")
-		  				|> range(start: %s,stop: %s)
-		  				|> filter(fn: (r) => r._measurement == "chain_activity_1d")
+						|> range(start: %s,stop: %s)
+						|> filter(fn: (r) => r._measurement == "chain_activity_1d")
 						%s
 						%s
 						%s
@@ -1330,7 +1325,7 @@ func (r *Repository) buildQueryChainActivityMonthly(start, stop, filterSourceCha
 						|> rename(columns: {_start: "_time"})
 						|> map(fn: (r) => ({r with to: string(v: r._stop)}))
 
-				vols = data		
+				vols = data
 						|> filter(fn: (r) => (r._field == "volume" and r._value > 0))
 						|> group(columns:["_time","to","emitter_chain"])
 						|> sum()
@@ -1343,14 +1338,13 @@ func (r *Repository) buildQueryChainActivityMonthly(start, stop, filterSourceCha
 						|> rename(columns: {_value: "count"})
 
 				join.inner(
-					    left: vols,
-					    right: counts,
-					    on: (l, r) => l._time == r._time and l.emitter_chain == r.emitter_chain,
-					    as: (l, r) => ({l with count: r.count}),
+						left: vols,
+						right: counts,
+						on: (l, r) => l._time == r._time and l.emitter_chain == r.emitter_chain,
+						as: (l, r) => ({l with count: r.count}),
 				)
 				|> group()
-				|> sort(columns:["emitter_chain","_time"],desc:false)
-		`
+				|> sort(columns:["emitter_chain","_time"],desc:false)`
 	return fmt.Sprintf(query, r.bucketInfiniteRetention, start, stop, filterSourceChain, filterTargetChain, filterAppId)
 }
 
@@ -1360,8 +1354,8 @@ func (r *Repository) buildQueryChainActivityYearly(start, stop, filterSourceChai
 				import "join"
 
 				data = from(bucket: "%s")
-		  				|> range(start: %s,stop: %s)
-		  				|> filter(fn: (r) => r._measurement == "chain_activity_1d")
+						|> range(start: %s,stop: %s)
+						|> filter(fn: (r) => r._measurement == "chain_activity_1d")
 						%s
 						%s
 						%s
@@ -1371,7 +1365,7 @@ func (r *Repository) buildQueryChainActivityYearly(start, stop, filterSourceChai
 						|> rename(columns: {_start: "_time"})
 						|> map(fn: (r) => ({r with to: string(v: r._stop)}))
 
-				vols = data		
+				vols = data
 						|> filter(fn: (r) => (r._field == "volume" and r._value > 0))
 						|> group(columns:["_time","to","emitter_chain"])
 						|> sum()
@@ -1384,13 +1378,12 @@ func (r *Repository) buildQueryChainActivityYearly(start, stop, filterSourceChai
 						|> rename(columns: {_value: "count"})
 
 				join.inner(
-					    left: vols,
-					    right: counts,
-					    on: (l, r) => l._time == r._time and l.emitter_chain == r.emitter_chain,
-					    as: (l, r) => ({l with count: r.count}),
+						left: vols,
+						right: counts,
+						on: (l, r) => l._time == r._time and l.emitter_chain == r.emitter_chain,
+						as: (l, r) => ({l with count: r.count}),
 				)
 				|> group()
-				|> sort(columns:["emitter_chain","_time"],desc:false)
-		`
+				|> sort(columns:["emitter_chain","_time"],desc:false)`
 	return fmt.Sprintf(query, r.bucketInfiniteRetention, start, stop, filterSourceChain, filterTargetChain, filterAppId)
 }

--- a/api/handlers/transactions/repository.go
+++ b/api/handlers/transactions/repository.go
@@ -1095,20 +1095,20 @@ func (r *Repository) buildChainActivityQueryTops(q ChainActivityTopsQuery) strin
 	}
 
 	filterTargetChain := ""
-	if len(q.TargetChain) > 0 {
-		val := fmt.Sprintf("r.destination_chain == \"%d\"", q.TargetChain[0])
+	if len(q.TargetChains) > 0 {
+		val := fmt.Sprintf("r.destination_chain == \"%d\"", q.TargetChains[0])
 		buff := ""
-		for _, tc := range q.TargetChain[1:] {
+		for _, tc := range q.TargetChains[1:] {
 			buff += fmt.Sprintf("or r.destination_chain == \"%d\" ", tc)
 		}
 		filterTargetChain = fmt.Sprintf("|> filter(fn: (r) => %s %s)", val, buff)
 	}
 
 	filterSourceChain := ""
-	if len(q.SourceChain) > 0 {
-		val := fmt.Sprintf("r.emitter_chain == \"%d\"", q.SourceChain[0])
+	if len(q.SourceChains) > 0 {
+		val := fmt.Sprintf("r.emitter_chain == \"%d\"", q.SourceChains[0])
 		buff := ""
-		for _, tc := range q.SourceChain[1:] {
+		for _, tc := range q.SourceChains[1:] {
 			buff += fmt.Sprintf("or r.emitter_chain == \"%d\" ", tc)
 		}
 		filterSourceChain = fmt.Sprintf("|> filter(fn: (r) => %s %s)", val, buff)
@@ -1119,7 +1119,7 @@ func (r *Repository) buildChainActivityQueryTops(q ChainActivityTopsQuery) strin
 		filterAppId = "|> filter(fn: (r) => r.app_id == \"" + q.AppId + "\")"
 	}
 
-	if q.TargetChain == nil && q.AppId == "" {
+	if len(q.TargetChains) == 0 && q.AppId == "" {
 		return r.buildQueryChainActivityTopsByEmitter(q, start, stop, filterSourceChain)
 	}
 

--- a/api/handlers/transactions/repository.go
+++ b/api/handlers/transactions/repository.go
@@ -1095,13 +1095,23 @@ func (r *Repository) buildChainActivityQueryTops(q ChainActivityTopsQuery) strin
 	}
 
 	filterTargetChain := ""
-	if q.TargetChain != nil {
-		filterTargetChain = "|> filter(fn: (r) => r.destination_chain == \"" + strconv.Itoa(int(*q.TargetChain)) + "\")"
+	if len(q.TargetChain) > 0 {
+		val := fmt.Sprintf("r.destination_chain == \"%d\"", q.TargetChain[0])
+		buff := ""
+		for _, tc := range q.TargetChain[1:] {
+			buff += fmt.Sprintf("or r.destination_chain == \"%d\" ", tc)
+		}
+		filterTargetChain = fmt.Sprintf("|> filter(fn: (r) => %s %s)", val, buff)
 	}
 
 	filterSourceChain := ""
-	if q.SourceChain != nil {
-		filterSourceChain = "|> filter(fn: (r) => r.emitter_chain == \"" + strconv.Itoa(int(*q.SourceChain)) + "\")"
+	if len(q.SourceChain) > 0 {
+		val := fmt.Sprintf("r.emitter_chain == \"%d\"", q.SourceChain[0])
+		buff := ""
+		for _, tc := range q.SourceChain[1:] {
+			buff += fmt.Sprintf("or r.emitter_chain == \"%d\" ", tc)
+		}
+		filterSourceChain = fmt.Sprintf("|> filter(fn: (r) => %s %s)", val, buff)
 	}
 
 	filterAppId := ""

--- a/api/handlers/transactions/repository_test.go
+++ b/api/handlers/transactions/repository_test.go
@@ -1,6 +1,11 @@
 package transactions
 
-import "testing"
+import (
+	"github.com/stretchr/testify/assert"
+	sdk "github.com/wormhole-foundation/wormhole/sdk/vaa"
+	"testing"
+	"time"
+)
 
 func Test_convertToDecimal(t *testing.T) {
 
@@ -35,4 +40,452 @@ func Test_convertToDecimal(t *testing.T) {
 		}
 	}
 
+}
+
+func Test_buildChainActivityQueryTops(t *testing.T) {
+
+	repository := &Repository{
+		bucketInfiniteRetention: "wormscan-testenv",
+	}
+
+	tcs := []struct {
+		name     string
+		input    ChainActivityTopsQuery
+		expected string
+	}{
+		{
+			name: "Search only by time range hourly",
+			input: ChainActivityTopsQuery{
+				SourceChains: []sdk.ChainID{},
+				TargetChains: []sdk.ChainID{},
+				From:         time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+				To:           time.Date(2024, 1, 3, 5, 30, 5, 0, time.UTC),
+				Timespan:     Hour,
+			},
+			expected: `
+					import "date"
+
+					from(bucket: "wormscan-testenv")
+					|> range(start: 2024-01-01T00:00:00Z,stop: 2024-01-03T05:00:00Z)
+					|> filter(fn: (r) => r._measurement == "emitter_chain_activity_1h")
+					
+					|> pivot(rowKey:["_time","emitter_chain"], columnKey: ["_field"], valueColumn: "_value")
+					|> sort(columns:["emitter_chain","_time"],desc:false)`,
+		},
+		{
+			name: "Search only by time range daily",
+			input: ChainActivityTopsQuery{
+				SourceChains: []sdk.ChainID{},
+				TargetChains: []sdk.ChainID{},
+				From:         time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+				To:           time.Date(2024, 1, 3, 5, 30, 5, 0, time.UTC),
+				Timespan:     Day,
+			},
+			expected: `
+					import "date"
+
+					from(bucket: "wormscan-testenv")
+					|> range(start: 2024-01-01T00:00:00Z,stop: 2024-01-03T00:00:00Z)
+					|> filter(fn: (r) => r._measurement == "emitter_chain_activity_1d")
+					
+					|> pivot(rowKey:["_time","emitter_chain"], columnKey: ["_field"], valueColumn: "_value")
+					|> sort(columns:["emitter_chain","_time"],desc:false)`,
+		},
+		{
+			name: "Search only by time range monthly",
+			input: ChainActivityTopsQuery{
+				SourceChains: []sdk.ChainID{},
+				TargetChains: []sdk.ChainID{},
+				From:         time.Date(2023, 10, 7, 0, 0, 0, 0, time.UTC),
+				To:           time.Date(2024, 1, 3, 5, 30, 5, 0, time.UTC),
+				Timespan:     Month,
+			},
+			expected: `
+				import "date"
+				import "join"
+
+				data = from(bucket: "wormscan-testenv")
+						|> range(start: 2023-10-01T00:00:00Z,stop: 2024-01-01T00:00:00Z)
+						|> filter(fn: (r) => r._measurement == "emitter_chain_activity_1d")
+						
+						|> drop(columns:["to"])
+						|> window(every: 1mo, period:1mo)
+						|> drop(columns:["_time"])
+						|> rename(columns: {_start: "_time"})
+						|> map(fn: (r) => ({r with to: string(v: r._stop)}))
+
+				vols = data
+						|> filter(fn: (r) => (r._field == "volume" and r._value > 0))
+						|> group(columns:["_time","to","emitter_chain"])
+						|> sum()
+						|> rename(columns: {_value: "volume"})
+
+				counts = data
+						|> filter(fn: (r) => (r._field == "count"))
+						|> group(columns:["_time","to","emitter_chain"])
+						|> sum()
+						|> rename(columns: {_value: "count"})
+
+				join.inner(
+						left: vols,
+						right: counts,
+						on: (l, r) => l._time == r._time and l.emitter_chain == r.emitter_chain,
+						as: (l, r) => ({l with count: r.count}),
+				)
+				|> group()
+				|> sort(columns:["emitter_chain","_time"],desc:false)`,
+		},
+		{
+			name: "Search only by time range yearly",
+			input: ChainActivityTopsQuery{
+				SourceChains: []sdk.ChainID{},
+				TargetChains: []sdk.ChainID{},
+				From:         time.Date(2020, 10, 7, 0, 0, 0, 0, time.UTC),
+				To:           time.Date(2024, 1, 3, 5, 30, 5, 0, time.UTC),
+				Timespan:     Year,
+			},
+			expected: `
+				import "date"
+				import "join"
+
+				data = from(bucket: "wormscan-testenv")
+						|> range(start: 2020-01-01T00:00:00Z,stop: 2024-01-01T00:00:00Z)
+						|> filter(fn: (r) => r._measurement == "emitter_chain_activity_1d")
+						
+						|> drop(columns:["to"])
+						|> window(every: 1y, period:1y)
+						|> drop(columns:["_time"])
+						|> rename(columns: {_start: "_time"})
+						|> map(fn: (r) => ({r with to: string(v: r._stop)}))
+
+				vols = data
+						|> group(columns:["_time","to","emitter_chain"])
+						|> sum()
+						|> rename(columns: {_value: "volume"})
+
+				counts = data
+						|> filter(fn: (r) => (r._field == "count"))
+						|> group(columns:["_time","to","emitter_chain"])
+						|> sum()
+						|> rename(columns: {_value: "count"})
+
+				join.inner(
+						left: vols,
+						right: counts,
+						on: (l, r) => l._time == r._time and l.emitter_chain == r.emitter_chain,
+						as: (l, r) => ({l with count: r.count}),
+				)
+				|> group()
+				|> sort(columns:["emitter_chain","_time"],desc:false)`,
+		},
+		{
+			name: "Search by emitter_chain daily",
+			input: ChainActivityTopsQuery{
+				SourceChains: []sdk.ChainID{1},
+				TargetChains: []sdk.ChainID{},
+				From:         time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+				To:           time.Date(2024, 1, 3, 5, 30, 5, 0, time.UTC),
+				Timespan:     Day,
+			},
+			expected: `
+					import "date"
+
+					from(bucket: "wormscan-testenv")
+					|> range(start: 2024-01-01T00:00:00Z,stop: 2024-01-03T00:00:00Z)
+					|> filter(fn: (r) => r._measurement == "emitter_chain_activity_1d")
+					|> filter(fn: (r) => r.emitter_chain == "1")
+					|> pivot(rowKey:["_time","emitter_chain"], columnKey: ["_field"], valueColumn: "_value")
+					|> sort(columns:["emitter_chain","_time"],desc:false)`,
+		},
+		{
+			name: "Search by multiple emitter_chain daily",
+			input: ChainActivityTopsQuery{
+				SourceChains: []sdk.ChainID{1, 2},
+				TargetChains: []sdk.ChainID{},
+				From:         time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+				To:           time.Date(2024, 1, 3, 5, 30, 5, 0, time.UTC),
+				Timespan:     Day,
+			},
+			expected: `
+					import "date"
+
+					from(bucket: "wormscan-testenv")
+					|> range(start: 2024-01-01T00:00:00Z,stop: 2024-01-03T00:00:00Z)
+					|> filter(fn: (r) => r._measurement == "emitter_chain_activity_1d")
+					|> filter(fn: (r) => r.emitter_chain == "1" or r.emitter_chain == "2")
+					|> pivot(rowKey:["_time","emitter_chain"], columnKey: ["_field"], valueColumn: "_value")
+					|> sort(columns:["emitter_chain","_time"],desc:false)`,
+		},
+		{
+			name: "Search by emitter_chain and target_chain hourly",
+			input: ChainActivityTopsQuery{
+				SourceChains: []sdk.ChainID{1},
+				TargetChains: []sdk.ChainID{2},
+				From:         time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+				To:           time.Date(2024, 1, 3, 5, 30, 5, 0, time.UTC),
+				Timespan:     Hour,
+			},
+			expected: `
+					import "date"
+					import "join"
+
+					data = from(bucket: "wormscan-testenv")
+		  			|> range(start: 2024-01-01T00:00:00Z,stop: 2024-01-03T05:00:00Z)
+		  			|> filter(fn: (r) => r._measurement == "chain_activity_1h")
+					|> filter(fn: (r) => r.emitter_chain == "1")
+					|> filter(fn: (r) => r.destination_chain == "2")
+					
+					|> drop(columns:["destination_chain"])
+
+					vols = data		
+						|> filter(fn: (r) => (r._field == "volume" and r._value > 0))
+						|> group(columns:["_time","to","emitter_chain"])
+						|> sum()
+						|> rename(columns: {_value: "volume"})
+
+					counts = data
+						|> filter(fn: (r) => (r._field == "count"))
+						|> group(columns:["_time","to","emitter_chain"])
+						|> sum()
+						|> rename(columns: {_value: "count"})
+
+					join.inner(
+					    left: vols,
+					    right: counts,
+					    on: (l, r) => l._time == r._time and l.to == r.to and l.emitter_chain == r.emitter_chain,
+					    as: (l, r) => ({l with count: r.count}),
+					)
+					|> group()
+					|> sort(columns:["emitter_chain","_time"],desc:false)`,
+		},
+		{
+			name: "Search by multiple emitter_chain and multiple target_chain daily",
+			input: ChainActivityTopsQuery{
+				SourceChains: []sdk.ChainID{1, 3},
+				TargetChains: []sdk.ChainID{2, 4},
+				From:         time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+				To:           time.Date(2024, 1, 3, 5, 30, 5, 0, time.UTC),
+				Timespan:     Day,
+			},
+			expected: `
+					import "date"
+					import "join"
+
+					data = from(bucket: "wormscan-testenv")
+		  			|> range(start: 2024-01-01T00:00:00Z,stop: 2024-01-03T00:00:00Z)
+		  			|> filter(fn: (r) => r._measurement == "chain_activity_1d")
+					|> filter(fn: (r) => r.emitter_chain == "1" or r.emitter_chain == "3")
+					|> filter(fn: (r) => r.destination_chain == "2" or r.destination_chain == "4")
+					
+					|> drop(columns:["destination_chain"])
+
+					vols = data		
+						|> filter(fn: (r) => (r._field == "volume" and r._value > 0))
+						|> group(columns:["_time","to","emitter_chain"])
+						|> sum()
+						|> rename(columns: {_value: "volume"})
+
+					counts = data
+						|> filter(fn: (r) => (r._field == "count"))
+						|> group(columns:["_time","to","emitter_chain"])
+						|> sum()
+						|> rename(columns: {_value: "count"})
+
+					join.inner(
+					    left: vols,
+					    right: counts,
+					    on: (l, r) => l._time == r._time and l.to == r.to and l.emitter_chain == r.emitter_chain,
+					    as: (l, r) => ({l with count: r.count}),
+					)
+					|> group()
+					|> sort(columns:["emitter_chain","_time"],desc:false)`,
+		},
+		{
+			name: "Search by app_id daily",
+			input: ChainActivityTopsQuery{
+				SourceChains: []sdk.ChainID{},
+				TargetChains: []sdk.ChainID{},
+				From:         time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+				To:           time.Date(2024, 1, 3, 5, 30, 5, 0, time.UTC),
+				Timespan:     Day,
+				AppId:        "CCTP_WORMHOLE_INTEGRATION",
+			},
+			expected: `
+					import "date"
+					import "join"
+
+					data = from(bucket: "wormscan-testenv")
+		  			|> range(start: 2024-01-01T00:00:00Z,stop: 2024-01-03T00:00:00Z)
+		  			|> filter(fn: (r) => r._measurement == "chain_activity_1d")
+					
+					
+					|> filter(fn: (r) => r.app_id == "CCTP_WORMHOLE_INTEGRATION")
+					|> drop(columns:["destination_chain"])
+
+					vols = data		
+						|> filter(fn: (r) => (r._field == "volume" and r._value > 0))
+						|> group(columns:["_time","to","emitter_chain"])
+						|> sum()
+						|> rename(columns: {_value: "volume"})
+
+					counts = data
+						|> filter(fn: (r) => (r._field == "count"))
+						|> group(columns:["_time","to","emitter_chain"])
+						|> sum()
+						|> rename(columns: {_value: "count"})
+
+					join.inner(
+					    left: vols,
+					    right: counts,
+					    on: (l, r) => l._time == r._time and l.to == r.to and l.emitter_chain == r.emitter_chain,
+					    as: (l, r) => ({l with count: r.count}),
+					)
+					|> group()
+					|> sort(columns:["emitter_chain","_time"],desc:false)`,
+		},
+		{
+			name: "Search by multiple emitter_chain, destination_chain and app_id daily",
+			input: ChainActivityTopsQuery{
+				SourceChains: []sdk.ChainID{1, 2},
+				TargetChains: []sdk.ChainID{3, 4},
+				From:         time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+				To:           time.Date(2024, 1, 3, 5, 30, 5, 0, time.UTC),
+				Timespan:     Day,
+				AppId:        "CCTP_WORMHOLE_INTEGRATION",
+			},
+			expected: `
+					import "date"
+					import "join"
+
+					data = from(bucket: "wormscan-testenv")
+		  			|> range(start: 2024-01-01T00:00:00Z,stop: 2024-01-03T00:00:00Z)
+		  			|> filter(fn: (r) => r._measurement == "chain_activity_1d")
+					|> filter(fn: (r) => r.emitter_chain == "1" or r.emitter_chain == "2")
+					|> filter(fn: (r) => r.destination_chain == "3" or r.destination_chain == "4")
+					|> filter(fn: (r) => r.app_id == "CCTP_WORMHOLE_INTEGRATION")
+					|> drop(columns:["destination_chain"])
+
+					vols = data		
+						|> filter(fn: (r) => (r._field == "volume" and r._value > 0))
+						|> group(columns:["_time","to","emitter_chain"])
+						|> sum()
+						|> rename(columns: {_value: "volume"})
+
+					counts = data
+						|> filter(fn: (r) => (r._field == "count"))
+						|> group(columns:["_time","to","emitter_chain"])
+						|> sum()
+						|> rename(columns: {_value: "count"})
+
+					join.inner(
+					    left: vols,
+					    right: counts,
+					    on: (l, r) => l._time == r._time and l.to == r.to and l.emitter_chain == r.emitter_chain,
+					    as: (l, r) => ({l with count: r.count}),
+					)
+					|> group()
+					|> sort(columns:["emitter_chain","_time"],desc:false)`,
+		},
+		{
+			name: "Search by multiple emitter_chain, destination_chain and app_id monthly",
+			input: ChainActivityTopsQuery{
+				SourceChains: []sdk.ChainID{1, 2},
+				TargetChains: []sdk.ChainID{3, 4},
+				From:         time.Date(2023, 9, 7, 0, 0, 0, 0, time.UTC),
+				To:           time.Date(2024, 3, 3, 5, 30, 5, 0, time.UTC),
+				Timespan:     Month,
+				AppId:        "CCTP_WORMHOLE_INTEGRATION",
+			},
+			expected: `
+				import "date"
+				import "join"
+
+				data = from(bucket: "wormscan-testenv")
+						|> range(start: 2023-09-01T00:00:00Z,stop: 2024-03-01T00:00:00Z)
+						|> filter(fn: (r) => r._measurement == "chain_activity_1d")
+						|> filter(fn: (r) => r.emitter_chain == "1" or r.emitter_chain == "2")
+						|> filter(fn: (r) => r.destination_chain == "3" or r.destination_chain == "4")
+						|> filter(fn: (r) => r.app_id == "CCTP_WORMHOLE_INTEGRATION")
+						|> drop(columns:["destination_chain","to","app_id"])
+						|> window(every: 1mo, period:1mo)
+						|> drop(columns:["_time"])
+						|> rename(columns: {_start: "_time"})
+						|> map(fn: (r) => ({r with to: string(v: r._stop)}))
+
+				vols = data
+						|> filter(fn: (r) => (r._field == "volume" and r._value > 0))
+						|> group(columns:["_time","to","emitter_chain"])
+						|> sum()
+						|> rename(columns: {_value: "volume"})
+
+				counts = data
+						|> filter(fn: (r) => (r._field == "count"))
+						|> group(columns:["_time","to","emitter_chain"])
+						|> sum()
+						|> rename(columns: {_value: "count"})
+
+				join.inner(
+						left: vols,
+						right: counts,
+						on: (l, r) => l._time == r._time and l.emitter_chain == r.emitter_chain,
+						as: (l, r) => ({l with count: r.count}),
+				)
+				|> group()
+				|> sort(columns:["emitter_chain","_time"],desc:false)`,
+		},
+		{
+			name: "Search by multiple emitter_chain, destination_chain and app_id yearly",
+			input: ChainActivityTopsQuery{
+				SourceChains: []sdk.ChainID{1, 2},
+				TargetChains: []sdk.ChainID{3, 4},
+				From:         time.Date(2020, 9, 7, 0, 0, 0, 0, time.UTC),
+				To:           time.Date(2024, 3, 3, 5, 30, 5, 0, time.UTC),
+				Timespan:     Year,
+				AppId:        "CCTP_WORMHOLE_INTEGRATION",
+			},
+			expected: `
+				import "date"
+				import "join"
+
+				data = from(bucket: "wormscan-testenv")
+						|> range(start: 2020-01-01T00:00:00Z,stop: 2024-01-01T00:00:00Z)
+						|> filter(fn: (r) => r._measurement == "chain_activity_1d")
+						|> filter(fn: (r) => r.emitter_chain == "1" or r.emitter_chain == "2")
+						|> filter(fn: (r) => r.destination_chain == "3" or r.destination_chain == "4")
+						|> filter(fn: (r) => r.app_id == "CCTP_WORMHOLE_INTEGRATION")
+						|> drop(columns:["destination_chain","to","app_id"])
+						|> window(every: 1y, period:1y)
+						|> drop(columns:["_time"])
+						|> rename(columns: {_start: "_time"})
+						|> map(fn: (r) => ({r with to: string(v: r._stop)}))
+
+				vols = data
+						|> filter(fn: (r) => (r._field == "volume" and r._value > 0))
+						|> group(columns:["_time","to","emitter_chain"])
+						|> sum()
+						|> rename(columns: {_value: "volume"})
+
+				counts = data
+						|> filter(fn: (r) => (r._field == "count"))
+						|> group(columns:["_time","to","emitter_chain"])
+						|> sum()
+						|> rename(columns: {_value: "count"})
+
+				join.inner(
+						left: vols,
+						right: counts,
+						on: (l, r) => l._time == r._time and l.emitter_chain == r.emitter_chain,
+						as: (l, r) => ({l with count: r.count}),
+				)
+				|> group()
+				|> sort(columns:["emitter_chain","_time"],desc:false)`,
+		},
+	}
+
+	for _, testCase := range tcs {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := repository.buildChainActivityQueryTops(testCase.input)
+			assert.Equal(t, testCase.expected, got, "Expected query did not match actual one.")
+		})
+	}
 }

--- a/api/middleware/extract_parameters.go
+++ b/api/middleware/extract_parameters.go
@@ -61,23 +61,6 @@ func ExtractToChain(c *fiber.Ctx, l *zap.Logger) (*sdk.ChainID, error) {
 	return &result, nil
 }
 
-func ExtractChain(c *fiber.Ctx, l *zap.Logger) (*sdk.ChainID, error) {
-	return extractChainQueryParam(c, l, "chain")
-}
-
-/*
-func ExtractSourceChain(c *fiber.Ctx, l *zap.Logger) (*sdk.ChainID, error) {
-	return extractChainQueryParam(c, l, "sourceChain")
-}
-
-
-
-func ExtractTargetChain(c *fiber.Ctx, l *zap.Logger) (*sdk.ChainID, error) {
-	return extractChainQueryParam(c, l, "targetChain")
-}
-
-*/
-
 func ExtractSourceChain(c *fiber.Ctx, l *zap.Logger) ([]sdk.ChainID, error) {
 	param := c.Query("sourceChain")
 	if param == "" {

--- a/api/routes/wormscan/operations/controller.go
+++ b/api/routes/wormscan/operations/controller.go
@@ -32,8 +32,8 @@ func NewController(operationService *operations.Service, logger *zap.Logger) *Co
 // @Param txHash query string false "hash of the transaction"
 // @Param page query integer false "page number"
 // @Param pageSize query integer false "pageSize". Maximum value is 100.
-// @Param sourceChain query string false "source chain of the operation".
-// @Param targetChain query string false "target chain of the operation".
+// @Param sourceChain query string false "source chains of the operation, separated by comma".
+// @Param targetChain query string false "target chains of the operation, separated by comma".
 // @Param appId query string false "appID of the operation".
 // @Param exclusiveAppId query boolean false "single appId of the operation".
 // @Success 200 {object} []OperationResponse

--- a/api/routes/wormscan/operations/controller.go
+++ b/api/routes/wormscan/operations/controller.go
@@ -1,14 +1,13 @@
 package operations
 
 import (
-	"strconv"
-	"strings"
-
 	"github.com/gofiber/fiber/v2"
 	"github.com/wormhole-foundation/wormhole-explorer/api/handlers/operations"
 	"github.com/wormhole-foundation/wormhole-explorer/api/middleware"
 	"github.com/wormhole-foundation/wormhole-explorer/api/response"
 	"go.uber.org/zap"
+	"strconv"
+	"strings"
 )
 
 // Controller is the controller for the operation resource.
@@ -76,8 +75,11 @@ func (c *Controller) FindAll(ctx *fiber.Ctx) error {
 		return err
 	}
 
-	//appID := middleware.ExtractAppId(ctx, c.logger)
-	appID := strings.Split(ctx.Query("appId"), ",")
+	var appIDs []string
+	appIDQueryParam := ctx.Query("appId")
+	if appIDQueryParam != "" {
+		appIDs = strings.Split(appIDQueryParam, ",")
+	}
 
 	exclusiveAppId, err := middleware.ExtractExclusiveAppId(ctx)
 	if err != nil {
@@ -85,7 +87,7 @@ func (c *Controller) FindAll(ctx *fiber.Ctx) error {
 	}
 
 	searchBySourceTargetChain := len(sourceChain) != 0 || targetChain != nil
-	searchByAppId := len(appID) != 0
+	searchByAppId := len(appIDs) != 0
 
 	if (searchByAddress || searchByTxHash) && (searchBySourceTargetChain || searchByAppId) {
 		return response.NewInvalidParamError(ctx, "address/txHash cannot be combined with sourceChain/targetChain/appId query filter", nil)
@@ -96,7 +98,7 @@ func (c *Controller) FindAll(ctx *fiber.Ctx) error {
 		Address:        address,
 		SourceChainIDs: sourceChain,
 		TargetChainIDs: targetChain,
-		AppID:          appID,
+		AppIDs:         appIDs,
 		ExclusiveAppId: exclusiveAppId,
 		Pagination:     *pagination,
 	}

--- a/api/routes/wormscan/operations/controller.go
+++ b/api/routes/wormscan/operations/controller.go
@@ -86,7 +86,7 @@ func (c *Controller) FindAll(ctx *fiber.Ctx) error {
 		return err
 	}
 
-	searchBySourceTargetChain := len(sourceChain) != 0 || targetChain != nil
+	searchBySourceTargetChain := len(sourceChain) > 0 || len(targetChain) > 0
 	searchByAppId := len(appIDs) != 0
 
 	if (searchByAddress || searchByTxHash) && (searchBySourceTargetChain || searchByAppId) {

--- a/api/routes/wormscan/operations/controller.go
+++ b/api/routes/wormscan/operations/controller.go
@@ -2,6 +2,7 @@ package operations
 
 import (
 	"strconv"
+	"strings"
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/wormhole-foundation/wormhole-explorer/api/handlers/operations"
@@ -75,14 +76,16 @@ func (c *Controller) FindAll(ctx *fiber.Ctx) error {
 		return err
 	}
 
-	appID := middleware.ExtractAppId(ctx, c.logger)
+	//appID := middleware.ExtractAppId(ctx, c.logger)
+	appID := strings.Split(ctx.Query("appId"), ",")
+
 	exclusiveAppId, err := middleware.ExtractExclusiveAppId(ctx)
 	if err != nil {
 		return err
 	}
 
-	searchBySourceTargetChain := sourceChain != nil || targetChain != nil
-	searchByAppId := appID != ""
+	searchBySourceTargetChain := len(sourceChain) != 0 || targetChain != nil
+	searchByAppId := len(appID) != 0
 
 	if (searchByAddress || searchByTxHash) && (searchBySourceTargetChain || searchByAppId) {
 		return response.NewInvalidParamError(ctx, "address/txHash cannot be combined with sourceChain/targetChain/appId query filter", nil)
@@ -91,8 +94,8 @@ func (c *Controller) FindAll(ctx *fiber.Ctx) error {
 	filter := operations.OperationFilter{
 		TxHash:         txHash,
 		Address:        address,
-		SourceChainID:  sourceChain,
-		TargetChainID:  targetChain,
+		SourceChainIDs: sourceChain,
+		TargetChainIDs: targetChain,
 		AppID:          appID,
 		ExclusiveAppId: exclusiveAppId,
 		Pagination:     *pagination,

--- a/api/routes/wormscan/transactions/controller.go
+++ b/api/routes/wormscan/transactions/controller.go
@@ -200,11 +200,11 @@ func (c *Controller) GetTopAssets(ctx *fiber.Ctx) error {
 // @Router /api/v1/x-chain-activity/tops [get]
 func (c *Controller) GetChainActivityTops(ctx *fiber.Ctx) error {
 
-	sourceChain, err := middleware.ExtractSourceChain(ctx, c.logger)
+	sourceChains, err := middleware.ExtractSourceChain(ctx, c.logger)
 	if err != nil {
 		return err
 	}
-	targetChain, err := middleware.ExtractTargetChain(ctx, c.logger)
+	targetChains, err := middleware.ExtractTargetChain(ctx, c.logger)
 	if err != nil {
 		return err
 	}
@@ -221,12 +221,12 @@ func (c *Controller) GetChainActivityTops(ctx *fiber.Ctx) error {
 	}
 
 	payload := transactions.ChainActivityTopsQuery{
-		SourceChain: sourceChain,
-		TargetChain: targetChain,
-		From:        *from,
-		To:          *to,
-		AppId:       middleware.ExtractAppId(ctx, c.logger),
-		Timespan:    transactions.Timespan(ctx.Query("timespan")),
+		SourceChains: sourceChains,
+		TargetChains: targetChains,
+		From:         *from,
+		To:           *to,
+		AppId:        middleware.ExtractAppId(ctx, c.logger),
+		Timespan:     transactions.Timespan(ctx.Query("timespan")),
 	}
 
 	if !payload.Timespan.IsValid() {


### PR DESCRIPTION
- #1335 
- Support querying with multiple sourceChains and targetChains in `/operations` endpoint.
- Support querying with multiple sourceChains,targetChains and appIds in `/transactions` endpoint.
- Add unit-tests to query builder methods.

### Examples
- Search operations by multiple source chain,target chain and appIds
[/api/v1/operations?sourceChain=6,10004&targetChain=1,2,4&appId=CCTP_WORMHOLE_INTEGRATION,PORTAL_TOKEN_BRIDGE&exclusiveAppId=false](https://api.testnet.wormscan.io/api/v1/operations?sourceChain=6,10004&targetChain=1,2,4&appId=CCTP_WORMHOLE_INTEGRATION,PORTAL_TOKEN_BRIDGE&exclusiveAppId=false)

- Search chain-activity-tops by multiple source chain,target chain and *single* appId.
[/v1/x-chain-activity/tops?from=2024-02-01T00:00:00Z&to=2024-02-15T00:00:00Z&timespan=1d&sourceChain=1,2,3,4,5&targetChain=5,6,7,8&appId=PORTAL_TOKEN_BRIDGE](https://api.testnet.wormscan.io/api/v1/x-chain-activity/tops?from=2024-02-01T00:00:00Z&to=2024-02-15T00:00:00Z&timespan=1d&sourceChain=1,2,3,4,5&targetChain=5,6,7,8&appId=PORTAL_TOKEN_BRIDGE)

