### PR TITLE
Add USDC.e fantom token to manual tokens config

### DIFF
--- a/common/domain/manual_mainnet_tokens.go
+++ b/common/domain/manual_mainnet_tokens.go
@@ -11,6 +11,7 @@ func manualMainnetTokenList() []TokenMetadata {
 		{TokenChain: 1, TokenAddress: "270ad0028e970df757d5f14f8cbb6a6810e48139125608ea958b718eb2944920", Symbol: "BORG", CoingeckoID: "swissborg", Decimals: 9},  // Addr: 3dQTr7ror2QPKQ3GbBCokJUmjErGg8kTJzdnYjNfvi3Z
 		{TokenChain: 2, TokenAddress: "00000000000000000000000064d0f55cd8c7133a9d7102b13987235f486f2224", Symbol: "BORG", CoingeckoID: "swissborg", Decimals: 18}, // Addr: 0x64d0f55cd8c7133a9d7102b13987235f486f2224
 
+		{TokenChain: 10, TokenAddress: "000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", Symbol: "USDC.e", CoingeckoID: "usdc", Decimals: 6}, // Addr: 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48
 	}
 }
 


### PR DESCRIPTION
Currently not tracked. Example: https://wormholescan.io/#/tx/0xc7696e9221fd61d1740ef9be54b5b26d91a2aaef731e190ed4722d2f1209a8d4

![image](https://github.com/wormhole-foundation/wormhole-explorer/assets/11276821/4a9b1269-847b-4626-b5c3-7204f31d8dd1)
