### PR TITLE
[Blockchain Watcher] (SOLANA) Change logs and execution job time

### DIFF
--- a/blockchain-watcher/src/domain/actions/solana/GetSolanaTransactions.ts
+++ b/blockchain-watcher/src/domain/actions/solana/GetSolanaTransactions.ts
@@ -48,7 +48,8 @@ export class GetSolanaTransactions {
           opts.signaturesLimit,
           opts.commitment
         );
-      this.logger.debug(
+
+      this.logger.info(
         `Got ${sigs.length} signatures for address ${programId} [blocks: ${
           range.fromBlock.blockTime
         } - ${range.toBlock.blockTime}][sigs: ${afterSignature.substring(

--- a/blockchain-watcher/src/domain/actions/solana/PollSolanaTransactions.ts
+++ b/blockchain-watcher/src/domain/actions/solana/PollSolanaTransactions.ts
@@ -60,8 +60,8 @@ export class PollSolanaTransactions extends RunPollingJob {
       return [];
     }
 
-    let toBlock = await this.findValidBlock(range.toSlot, (slot) => slot - 1);
     let fromBlock = await this.findValidBlock(range.fromSlot, (slot) => slot + 1);
+    let toBlock = await this.findValidBlock(range.toSlot, (slot) => slot - 1);
 
     if (!fromBlock.blockTime || !toBlock.blockTime || fromBlock.blockTime > toBlock.blockTime) {
       // TODO: validate if this is correct
@@ -70,7 +70,7 @@ export class PollSolanaTransactions extends RunPollingJob {
       );
     }
 
-    // signatures for address goes back from current sig
+    // Signatures for address goes back from current sig
     const afterSignature = fromBlock.transactions[0]?.transaction.signatures[0];
     let beforeSignature: string | undefined =
       toBlock.transactions[toBlock.transactions.length - 1]?.transaction.signatures[0];

--- a/deploy/blockchain-watcher/workers/solana-source-events-1.yaml
+++ b/deploy/blockchain-watcher/workers/solana-source-events-1.yaml
@@ -44,7 +44,7 @@ data:
           "config": {
             "slotBatchSize": 1000,
             "commitment": "finalized",
-            "interval": 5000,
+            "interval": 15000,
             "signaturesLimit": 100,
             "programIds": ["3u8hJUVTA4jH1wYAyUur7FFZVQ8H635K3tSHHF4ssjQ5"],
             "chain": "solana",
@@ -75,7 +75,7 @@ data:
           "config": {
             "slotBatchSize": 1000,
             "commitment": "finalized",
-            "interval": 1500,
+            "interval": 15000,
             "signaturesLimit": 200,
             "programIds": ["worm2ZoG2kUd4vFXhvjh93UUH596ayRfgQ2MgjNMTth"],
             "chain": "solana",

--- a/deploy/blockchain-watcher/workers/solana-target-events-1.yaml
+++ b/deploy/blockchain-watcher/workers/solana-target-events-1.yaml
@@ -45,7 +45,7 @@ data:
           "config": {
             "slotBatchSize": 1000,
             "commitment": "finalized",
-            "interval": 1500,
+            "interval": 15000,
             "signaturesLimit": 200,
             "programIds": [
               "DZnkkTmCiFWfYTfT41X3Rd1kDgozqzxWaHqsw6W4x2oe",
@@ -93,7 +93,7 @@ data:
           "config": {
             "slotBatchSize": 1000,
             "commitment": "finalized",
-            "interval": 1500,
+            "interval": 15000,
             "signaturesLimit": 200,
             "programIds": [
               "wormDTUJ6AWPNvk59vGQbDvGJmqbDTdgWgAqcLBCgUb",


### PR DESCRIPTION
## Link Issue


## Description
Improve execution job time. We have execution by 1.5 second the job and with this process we were a lot of issues about slot batches process (fromBlock > toBlock). 

- old time: 1.5 s
- new time: 15s

Error:
blockchain-watcher-solana-source-events-1-55cffcc977-dkrcp: error [PollSolanaTransactions][poll-log-message-published-solana] [run] Error processing items Invalid slot range: fromSlot=269882473 toSlot=269882438. Might be cause we are up to date.

## Test or Screenshots
<img width="1770" alt="image" src="https://github.com/wormhole-foundation/wormhole-explorer/assets/52217955/5c2f2605-ed52-4923-a816-5df08b5e47d6">

Source events process:
<img width="1163" alt="image" src="https://github.com/wormhole-foundation/wormhole-explorer/assets/52217955/f4126540-4c63-45a9-92f3-b01f4e38f2e8">

Target events process:
<img width="1385" alt="image" src="https://github.com/wormhole-foundation/wormhole-explorer/assets/52217955/41eef883-ea6d-4b01-a019-3144a0a476f6">
