### PR TITLE
[#1495] Add NTT Protocol Data to /api/v1/protocols/stats Endpoint

### DIFF
--- a/api/handlers/protocols/repository.go
+++ b/api/handlers/protocols/repository.go
@@ -19,7 +19,8 @@ const QueryCoreProtocolTotalStartOfDay = `
 		
 	data =	from(bucket: "%s")
 		|> range(start: 1970-01-01T00:00:00Z,stop:startOfCurrentDay)
-		|> filter(fn: (r) => r._measurement == "%s" and r.app_id == "%s")
+		|> filter(fn: (r) => r._measurement == "%s" and r.version == "v1" and r.app_id == "TOTAL_%s")
+		|> drop(columns: ["emitter_chain","destination_chain","version"])
 		
 tvt = data	
 		|> filter(fn : (r) => r._field == "total_value_transferred")
@@ -51,7 +52,8 @@ const QueryCoreProtocolDeltaSinceStartOfDay = `
 		
 	data =	from(bucket: "%s")
 		|> range(start: startOfDay,stop:ts)
-		|> filter(fn: (r) => r._measurement == "%s" and r.app_id == "%s")
+		|> filter(fn: (r) => r._measurement == "%s" and r.app_id == "TOTAL_%s")
+		|> drop(columns: ["emitter_chain","destination_chain","version"])
 		
 tvt =	data	
 		|> filter(fn : (r) => r._field == "total_value_transferred")
@@ -83,7 +85,8 @@ const QueryCoreProtocolDeltaLastDay = `
 		
 	data =	from(bucket: "%s")
 		|> range(start: yesterday,stop:ts)
-		|> filter(fn: (r) => r._measurement == "%s" and r.app_id == "%s")
+		|> filter(fn: (r) => r._measurement == "%s" and r.app_id == "TOTAL_%s")
+		|> drop(columns: ["emitter_chain","destination_chain"])
 		
 tvt =	data	
 		|> filter(fn : (r) => r._field == "total_value_transferred")
@@ -241,9 +244,10 @@ func NewRepository(qApi QueryDoer, bucketInfinite, bucket30d string, logger *zap
 		coreProtocolMeasurement: map[string]struct {
 			Daily  string
 			Hourly string
-		}{
-			CCTP:              {Daily: dbconsts.CctpStatsMeasurementDaily, Hourly: dbconsts.CctpStatsMeasurementHourly},
-			PortalTokenBridge: {Daily: dbconsts.TokenBridgeStatsMeasurementDaily, Hourly: dbconsts.TokenBridgeStatsMeasurementHourly},
+		}{ // TODO:corregir esto
+			CCTP:              {Daily: "protocols_stats_totals_1d", Hourly: "protocols_stats_totals_1h"},
+			PortalTokenBridge: {Daily: "protocols_stats_totals_1d", Hourly: "protocols_stats_totals_1h"},
+			NTT:               {Daily: "protocols_stats_totals_1d", Hourly: "protocols_stats_totals_1h"},
 		},
 	}
 }

--- a/api/handlers/protocols/service.go
+++ b/api/handlers/protocols/service.go
@@ -14,6 +14,7 @@ import (
 
 const CCTP = "CCTP_WORMHOLE_INTEGRATION"
 const PortalTokenBridge = "PORTAL_TOKEN_BRIDGE"
+const NTT = "NATIVE_TOKEN_TRANSFER"
 
 type Service struct {
 	Protocols      []string
@@ -90,6 +91,8 @@ func getProtocolNameDto(protocol string) string {
 		return "cctp"
 	case PortalTokenBridge:
 		return "portal_token_bridge"
+	case NTT:
+		return strings.ToLower(NTT)
 	default:
 		return protocol
 	}

--- a/api/handlers/protocols/service_test.go
+++ b/api/handlers/protocols/service_test.go
@@ -239,9 +239,9 @@ func TestService_GetCCTP_Stats(t *testing.T) {
 	ctx := context.Background()
 	queryAPI := &mockQueryAPI{}
 
-	queryAPI.On("Query", ctx, fmt.Sprintf(protocols.QueryCoreProtocolTotalStartOfDay, "bucketInfinite", dbconsts.CctpStatsMeasurementDaily, protocols.PortalTokenBridge, protocols.PortalTokenBridge)).Return(totalStartOfCurrentDay, errNil)
-	queryAPI.On("Query", ctx, fmt.Sprintf(protocols.QueryCoreProtocolDeltaSinceStartOfDay, "bucket30d", dbconsts.CctpStatsMeasurementHourly, protocols.PortalTokenBridge, protocols.PortalTokenBridge)).Return(deltaSinceStartOfDay, errNil)
-	queryAPI.On("Query", ctx, fmt.Sprintf(protocols.QueryCoreProtocolDeltaLastDay, "bucket30d", dbconsts.CctpStatsMeasurementHourly, protocols.PortalTokenBridge, protocols.PortalTokenBridge)).Return(deltaLastDay, errNil)
+	queryAPI.On("Query", ctx, fmt.Sprintf(protocols.QueryCoreProtocolTotalStartOfDay, "bucketInfinite", dbconsts.TotalProtocolsStatsDaily, protocols.PortalTokenBridge, protocols.PortalTokenBridge)).Return(totalStartOfCurrentDay, errNil)
+	queryAPI.On("Query", ctx, fmt.Sprintf(protocols.QueryCoreProtocolDeltaSinceStartOfDay, "bucket30d", dbconsts.TotalProtocolsStatsHourly, protocols.PortalTokenBridge, protocols.PortalTokenBridge)).Return(deltaSinceStartOfDay, errNil)
+	queryAPI.On("Query", ctx, fmt.Sprintf(protocols.QueryCoreProtocolDeltaLastDay, "bucket30d", dbconsts.TotalProtocolsStatsHourly, protocols.PortalTokenBridge, protocols.PortalTokenBridge)).Return(deltaLastDay, errNil)
 
 	repository := protocols.NewRepository(queryAPI, "bucketInfinite", "bucket30d", zap.NewNop())
 	service := protocols.NewService([]string{}, []string{protocols.PortalTokenBridge}, repository, zap.NewNop(), cache.NewDummyCacheClient(), "WORMSCAN:PROTOCOLS", 0, metrics.NewNoOpMetrics(), &mockTvl{})

--- a/api/main.go
+++ b/api/main.go
@@ -182,7 +182,7 @@ func main() {
 	relaysService := relays.NewService(relaysRepo, rootLogger)
 	operationsService := operations.NewService(operationsRepo, rootLogger)
 	statsService := stats.NewService(statsRepo, cache, expirationTime, metrics, rootLogger)
-	protocolsService := protocols.NewService(cfg.Protocols, []string{protocols.CCTP, protocols.PortalTokenBridge}, protocolsRepo, rootLogger, cache, cfg.Cache.ProtocolsStatsKey, cfg.Cache.ProtocolsStatsExpiration, metrics, tvl)
+	protocolsService := protocols.NewService(cfg.Protocols, []string{protocols.CCTP, protocols.PortalTokenBridge, protocols.NTT}, protocolsRepo, rootLogger, cache, cfg.Cache.ProtocolsStatsKey, cfg.Cache.ProtocolsStatsExpiration, metrics, tvl)
 	guardianService := guardianHandlers.NewService(guardianSetRepository, cfg.P2pNetwork, cache, metrics, rootLogger)
 
 	// Set up a custom error handler

--- a/common/dbconsts/consts.go
+++ b/common/dbconsts/consts.go
@@ -1,17 +1,10 @@
 package dbconsts
 
-// influx-db constants
 const (
 	ProtocolsActivityMeasurementHourly = "protocols_activity_1h"
 	ProtocolsActivityMeasurementDaily  = "protocols_activity_1d"
 	ProtocolsStatsMeasurementDaily     = "protocols_stats_1d"
 	ProtocolsStatsMeasurementHourly    = "protocols_stats_1h"
-
-	CctpStatsMeasurementHourly        = intProtocolStatsMeasurement1h
-	TokenBridgeStatsMeasurementHourly = intProtocolStatsMeasurement1h
-	intProtocolStatsMeasurement1h     = "core_protocols_stats_1h"
-
-	CctpStatsMeasurementDaily        = intProtocolStatsMeasurement1d
-	TokenBridgeStatsMeasurementDaily = intProtocolStatsMeasurement1d
-	intProtocolStatsMeasurement1d    = "core_protocols_stats_1d"
+	TotalProtocolsStatsDaily           = "protocols_stats_totals_1d"
+	TotalProtocolsStatsHourly          = "protocols_stats_totals_1h"
 )


### PR DESCRIPTION
- Add `NTT` to `/api/v1/protocols/stats` [endpoint](https://api.staging.wormscan.io/api/v1/protocols/stats) response.

Now the endpoint responds

```
[
  {
    "protocol": "portal_token_bridge",
    "total_messages": 3772285,
    "total_value_locked": 1534312151.7121854,
    "total_value_transferred": 42771606350.56895,
    "last_day_messages": 2366,
    "last_day_diff_percentage": "0.06%"
  },
  {
    "protocol": "cctp",
    "total_messages": 92014,
    "total_value_transferred": 418753766.55635583,
    "last_day_messages": 85,
    "last_day_diff_percentage": "0.09%"
  },
  {
    "protocol": "native_token_transfer",
    "total_messages": 83841,
    "total_value_transferred": 89346433.64697778,
    "last_day_messages": 560,
    "last_day_diff_percentage": "0.67%"
  },
  {
    "protocol": "allbridge",
    "total_messages": 60654,
    "total_value_transferred": 66805538.050969616,
    "last_day_messages": 932,
    "last_day_diff_percentage": "1.56%"
  },
  {
    "protocol": "mayan",
    "total_messages": 517425,
    "total_value_locked": 316668072.2592514,
    "total_value_secured": 316872220.7340726,
    "total_value_transferred": 520039812.84704286,
    "last_day_messages": 454,
    "last_day_diff_percentage": "0.09%"
  }
]
```