### PR TITLE
[Blockchain Watcher] (PODS) Change interval values

### DIFF
--- a/deploy/blockchain-watcher/workers/target-events-1.yaml
+++ b/deploy/blockchain-watcher/workers/target-events-1.yaml
@@ -45,7 +45,7 @@ data:
           "config": {
             "blockBatchSize": 100,
             "commitment": "latest",
-            "interval": 15000,
+            "interval": 35000,
             "filters": [
               {
                 "addresses": [],
@@ -102,7 +102,7 @@ data:
           "config": {
             "blockBatchSize": 1000,
             "commitment": "latest",
-            "interval": 15000,
+            "interval": 35000,
             "filters": [
               {
                 "addresses": [],
@@ -159,7 +159,7 @@ data:
           "config": {
             "blockBatchSize": 100,
             "commitment": "latest",
-            "interval": 15000,
+            "interval": 35000,
             "filters": [
               {
                 "addresses": [],
@@ -199,7 +199,7 @@ data:
           "config": {
             "blockBatchSize": 100,
             "commitment": "finalized",
-            "interval": 15000,
+            "interval": 35000,
             "filters": [
               {
                 "addresses": ["0x61E44E506Ca5659E6c0bba9b678586fA2d729756", "0x1fb8B6743E8d4F8047cd9C216192D4cD897947a2"],
@@ -262,7 +262,7 @@ data:
           "config": {
             "blockBatchSize": 100,
             "commitment": "latest",
-            "interval": 15000,
+            "interval": 35000,
             "filters": [
               {
                 "addresses": [],
@@ -319,7 +319,7 @@ data:
           "config": {
             "blockBatchSize": 100,
             "commitment": "latest",
-            "interval": 15000,
+            "interval": 60000,
             "filters": [
               {
                 "addresses": [],
@@ -358,7 +358,7 @@ data:
           "config": {
             "blockBatchSize": 100,
             "commitment": "latest",
-            "interval": 15000,
+            "interval": 35000,
             "filters": [
               {
                 "addresses": [],
@@ -403,7 +403,7 @@ data:
           "config": {
             "blockBatchSize": 100,
             "commitment": "latest",
-            "interval": 15000,
+            "interval": 35000,
             "filters": [
               {
                 "addresses": [],
@@ -460,7 +460,7 @@ data:
           "config": {
             "blockBatchSize": 100,
             "commitment": "latest",
-            "interval": 15000,
+            "interval": 35000,
             "filters": [
               {
                 "addresses": [],
@@ -493,7 +493,7 @@ data:
           "config": {
             "blockBatchSize": 4,
             "commitment": "latest",
-            "interval": 5000,
+            "interval": 35000,
             "filters": [
               {
                 "addresses": [],

--- a/deploy/blockchain-watcher/workers/target-events-1.yaml
+++ b/deploy/blockchain-watcher/workers/target-events-1.yaml
@@ -493,7 +493,7 @@ data:
           "config": {
             "blockBatchSize": 4,
             "commitment": "latest",
-            "interval": 35000,
+            "interval": 5000,
             "filters": [
               {
                 "addresses": [],

--- a/deploy/blockchain-watcher/workers/target-events-2.yaml
+++ b/deploy/blockchain-watcher/workers/target-events-2.yaml
@@ -45,7 +45,7 @@ data:
           "config": {
             "blockBatchSize": 100,
             "commitment": "latest",
-            "interval": 15000,
+            "interval": 35000,
             "filters": [
               {
                 "addresses": [],
@@ -84,7 +84,7 @@ data:
           "config": {
             "blockBatchSize": 100,
             "commitment": "latest",
-            "interval": 15000,
+            "interval": 35000,
             "filters": [
               {
                 "addresses": [],
@@ -123,7 +123,7 @@ data:
           "config": {
             "blockBatchSize": 100,
             "commitment": "latest",
-            "interval": 15000,
+            "interval": 35000,
             "filters": [
               {
                 "addresses": ["0xbc976D4b9D57E57c3cA52e1Fd136C45FF7955A96"],
@@ -174,8 +174,14 @@ data:
           "config": {
             "blockBatchSize": 100,
             "commitment": "latest",
-            "interval": 15000,
+            "interval": 35000,
             "filters": [
+              {
+                "addresses": ["0x05ca6037eC51F8b712eD2E6Fa72219FEaE74E153"],
+                "type": "Portal Token Bridge by contract and topic",
+                "topics": ["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"],
+                "strategy": "GetTransactionsByBlocksStrategy"
+              },
               {
                 "addresses": [],
                 "type": "Portal Token Bridge (Connect, Portico, Omniswap, tBTC, etc)",
@@ -219,7 +225,7 @@ data:
           "config": {
             "blockBatchSize": 100,
             "commitment": "latest",
-            "interval": 15000,
+            "interval": 35000,
             "filters": [
               {
                 "addresses": [],
@@ -252,7 +258,7 @@ data:
           "config": {
             "blockBatchSize": 100,
             "commitment": "latest",
-            "interval": 15000,
+            "interval": 35000,
             "filters": [
               {
                 "addresses": [],
@@ -283,9 +289,9 @@ data:
           "action": "PollEvm",
           "records": "GetEvmTransactions",
           "config": {
-            "blockBatchSize": 100,
-            "commitment": "latest",
-            "interval": 25000,
+            "blockBatchSize": 10,
+            "commitment": "finalized",
+            "interval": 60000,
             "filters": [
               {
                 "addresses": [],
@@ -576,9 +582,9 @@ data:
           "action": "PollEvm",
           "records": "GetEvmTransactions",
           "config": {
-            "blockBatchSize": 100,
-            "commitment": "latest",
-            "interval": 25000,
+            "blockBatchSize": 10,
+            "commitment": "finalized",
+            "interval": 60000,
             "filters": [
               {
                 "addresses": [],

--- a/deploy/blockchain-watcher/workers/target-events-3.yaml
+++ b/deploy/blockchain-watcher/workers/target-events-3.yaml
@@ -45,7 +45,7 @@ data:
           "config": {
             "limitBatchSize": 100,
             "commitment": "finalized",
-            "interval": 5000,
+            "interval": 35000,
             "addresses": [
               "0x576410486a2da45eee6c949c995670112ddf2fbeedab20350d506328eefc9d4f",
               "0x1bdffae984043833ed7fe223f7af7a3f8902d04129b14f801823e64827da7130"
@@ -81,7 +81,7 @@ data:
         "source": {
           "action": "PollSuiTransactions",
           "config": {
-            "interval": 5000,
+            "interval": 35000,
             "chain": "sui",
             "filter": {
               "MoveFunction": {
@@ -112,7 +112,7 @@ data:
         "source": {
           "action": "PollSuiTransactions",
           "config": {
-            "interval": 5000,
+            "interval": 35000,
             "chain": "sui",
             "filter": {
               "MoveFunction": {
@@ -146,7 +146,7 @@ data:
           "config": {
             "blockBatchSize": 50,
             "commitment": "latest",
-            "interval": 15000,
+            "interval": 35000,
             "addresses": ["wormhole1aaf9r6s7nxhysuegqrxv0wpm27ypyv4886medd3mrkrw6t4yfcnst3qpex"],
             "chain": "wormchain",
             "chainId": 3104
@@ -175,7 +175,7 @@ data:
           "config": {
             "blockBatchSize": 100,
             "commitment": "latest",
-            "interval": 25000,
+            "interval": 35000,
             "applicationIds": ["86525641"],
             "chain": "algorand",
             "chainId": 8
@@ -207,7 +207,7 @@ data:
           "config": {
             "blockBatchSize": 100,
             "commitment": "latest",
-            "interval": 15000,
+            "interval": 35000,
             "filters": [
               {
                 "addresses": [],
@@ -238,9 +238,9 @@ data:
           "action": "PollEvm",
           "records": "GetEvmTransactions",
           "config": {
-            "blockBatchSize": 100,
-            "commitment": "latest",
-            "interval": 35000,
+            "blockBatchSize": 10,
+            "commitment": "finalized",
+            "interval": 60000,
             "filters": [
               {
                 "addresses": [],
@@ -502,9 +502,9 @@ data:
           "action": "PollEvm",
           "records": "GetEvmTransactions",
           "config": {
-            "blockBatchSize": 100,
-            "commitment": "latest",
-            "interval": 15000,
+            "blockBatchSize": 10,
+            "commitment": "finalized",
+            "interval": 60000,
             "filters": [
               {
                 "addresses": [],


### PR DESCRIPTION
- Add new filter for celo
  - Contract: 0x05ca6037eC51F8b712eD2E6Fa72219FEaE74E153
  - Topic: 0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef

- Change interval time execution in testnet pod
  - We do not have a lot traffic in testnet for this reason we can reduce the execution time

- Change interval and commitment value in acala and karura. (latest => finalized)
   - We change the commitment because acala anad karura need use finalized to catch the redeems and we have reduce the execution time for this both jobs