### PR TITLE
[1528] add new filter payloadtype in operations endpoint

### DIFF
--- a/api/handlers/operations/repository.go
+++ b/api/handlers/operations/repository.go
@@ -255,7 +255,7 @@ func BuildPipelineSearchFromParsedVaa(query OperationQuery) mongo.Pipeline {
 	var pipeline mongo.Pipeline
 
 	if query.PayloadType != nil {
-		pipeline = append(pipeline, bson.D{{Key: "$match", Value: bson.D{{Key: "parsedPayload.type", Value: *query.PayloadType}}}})
+		pipeline = append(pipeline, bson.D{{Key: "$match", Value: bson.D{{Key: "parsedPayload.payloadType", Value: *query.PayloadType}}}})
 	}
 
 	if len(query.SourceChainIDs) > 0 || len(query.TargetChainIDs) > 0 {

--- a/api/handlers/operations/repository_test.go
+++ b/api/handlers/operations/repository_test.go
@@ -228,7 +228,7 @@ func TestPipeline_FindByChainAndAppId(t *testing.T) {
 
 	for _, testCase := range cases {
 		t.Run(testCase.name, func(t *testing.T) {
-			result := operations.BuildPipelineSearchByChainAndAppID(testCase.query)
+			result := operations.BuildPipelineSearchFromParsedVaa(testCase.query)
 			assert.Equal(t, testCase.expected, result, "Expected pipeline did not match actual pipeline")
 		})
 	}

--- a/api/handlers/operations/service.go
+++ b/api/handlers/operations/service.go
@@ -39,6 +39,7 @@ type OperationFilter struct {
 	AppIDs         []string
 	ExclusiveAppId bool
 	Pagination     pagination.Pagination
+	PayloadType    *int
 }
 
 // FindAll returns all operations filtered by q.
@@ -56,10 +57,11 @@ func (s *Service) FindAll(ctx context.Context, filter OperationFilter) ([]*Opera
 		TargetChainIDs: filter.TargetChainIDs,
 		AppIDs:         filter.AppIDs,
 		ExclusiveAppId: filter.ExclusiveAppId,
+		PayloadType:    filter.PayloadType,
 	}
 
-	if len(operationQuery.AppIDs) != 0 || len(operationQuery.SourceChainIDs) > 0 || len(operationQuery.TargetChainIDs) > 0 {
-		return s.repo.FindByChainAndAppId(ctx, operationQuery)
+	if len(operationQuery.AppIDs) != 0 || len(operationQuery.SourceChainIDs) > 0 || len(operationQuery.TargetChainIDs) > 0 || operationQuery.PayloadType != nil {
+		return s.repo.FindFromParsedVaa(ctx, operationQuery)
 	}
 
 	operations, err := s.repo.FindAll(ctx, operationQuery)

--- a/api/routes/wormscan/operations/controller.go
+++ b/api/routes/wormscan/operations/controller.go
@@ -93,6 +93,16 @@ func (c *Controller) FindAll(ctx *fiber.Ctx) error {
 		return response.NewInvalidParamError(ctx, "address/txHash cannot be combined with sourceChain/targetChain/appId query filter", nil)
 	}
 
+	payloadTypeParam := ctx.Query("payloadType")
+	var payloadType *int
+	if payloadTypeParam != "" {
+		ptype, err := strconv.Atoi(payloadTypeParam)
+		if err != nil {
+			return response.NewInvalidParamError(ctx, "invalid payloadType", err)
+		}
+		payloadType = &ptype
+	}
+
 	filter := operations.OperationFilter{
 		TxHash:         txHash,
 		Address:        address,
@@ -100,6 +110,7 @@ func (c *Controller) FindAll(ctx *fiber.Ctx) error {
 		TargetChainIDs: targetChain,
 		AppIDs:         appIDs,
 		ExclusiveAppId: exclusiveAppId,
+		PayloadType:    payloadType,
 		Pagination:     *pagination,
 	}
 

--- a/fly/migration/migration.go
+++ b/fly/migration/migration.go
@@ -258,6 +258,19 @@ func Run(db *mongo.Database) error {
 		return err
 	}
 
+	// create index for querying by payloadType
+	indexParsedVaaByPayloadType := mongo.IndexModel{
+		Keys: bson.D{
+			{Key: "parsedPayload.payloadType", Value: 1},
+			{Key: "timestamp", Value: -1},
+			{Key: "_id", Value: -1},
+		},
+	}
+	_, err = db.Collection("parsedVaa").Indexes().CreateOne(context.TODO(), indexParsedVaaByPayloadType)
+	if err != nil && isNotAlreadyExistsError(err) {
+		return err
+	}
+
 	// create index for duplicateVaas by vaaId
 	indexDuplicateVaasByVaadID := mongo.IndexModel{
 		Keys: bson.D{


### PR DESCRIPTION
- Issue: #1528 
- Add `payloadType` filter to `/operations`.
- Create index in mongodb parsedVaa collection:
  - ` db.parsedVaa.createIndex({
	"parsedPayload.payloadType": 1,
	"timestamp":-1,
	"_id":-1
})
 `
- Example: `https://api.testnet.wormscan.io/api/v1/operations?payloadType=2`  