### PR TITLE
#1589 add support for multiple payloadTypes in /operations endpoint

### DIFF
--- a/api/handlers/operations/repository.go
+++ b/api/handlers/operations/repository.go
@@ -116,7 +116,7 @@ type OperationQuery struct {
 	TargetChainIDs []vaa.ChainID
 	AppIDs         []string
 	ExclusiveAppId bool
-	PayloadType    *int
+	PayloadType    []int
 }
 
 func buildQueryOperationsByChain(sourceChainIDs, targetChainIDs []vaa.ChainID) bson.D {
@@ -254,8 +254,9 @@ func BuildPipelineSearchFromParsedVaa(query OperationQuery) mongo.Pipeline {
 
 	var pipeline mongo.Pipeline
 
-	if query.PayloadType != nil {
-		pipeline = append(pipeline, bson.D{{Key: "$match", Value: bson.D{{Key: "parsedPayload.payloadType", Value: *query.PayloadType}}}})
+	if len(query.PayloadType) > 0 {
+		payloadTypeFilter := bson.D{{Key: "$match", Value: bson.M{"parsedPayload.payloadType": bson.M{"$in": query.PayloadType}}}}
+		pipeline = append(pipeline, payloadTypeFilter)
 	}
 
 	if len(query.SourceChainIDs) > 0 || len(query.TargetChainIDs) > 0 {

--- a/api/handlers/operations/repository_test.go
+++ b/api/handlers/operations/repository_test.go
@@ -224,6 +224,23 @@ func TestPipeline_FindByChainAndAppId(t *testing.T) {
 				unSetStage,
 			},
 		},
+		{
+			name: "Search by payload type",
+			query: operations.OperationQuery{
+				PayloadType: []int{1, 2},
+			},
+			expected: mongo.Pipeline{
+				bson.D{{"$match", bson.M{"parsedPayload.payloadType": bson.M{"$in": []int{1, 2}}}}},
+				sortStage,
+				skipStage,
+				limitStage,
+				lookupVaasStage,
+				lookupTransferPricesStage,
+				lookupGlobalTransactionsStage,
+				addFieldsStage,
+				unSetStage,
+			},
+		},
 	}
 
 	for _, testCase := range cases {

--- a/api/handlers/operations/service.go
+++ b/api/handlers/operations/service.go
@@ -39,7 +39,7 @@ type OperationFilter struct {
 	AppIDs         []string
 	ExclusiveAppId bool
 	Pagination     pagination.Pagination
-	PayloadType    *int
+	PayloadType    []int
 }
 
 // FindAll returns all operations filtered by q.
@@ -60,7 +60,7 @@ func (s *Service) FindAll(ctx context.Context, filter OperationFilter) ([]*Opera
 		PayloadType:    filter.PayloadType,
 	}
 
-	if len(operationQuery.AppIDs) != 0 || len(operationQuery.SourceChainIDs) > 0 || len(operationQuery.TargetChainIDs) > 0 || operationQuery.PayloadType != nil {
+	if len(operationQuery.AppIDs) != 0 || len(operationQuery.SourceChainIDs) > 0 || len(operationQuery.TargetChainIDs) > 0 || len(operationQuery.PayloadType) > 0 {
 		return s.repo.FindFromParsedVaa(ctx, operationQuery)
 	}
 

--- a/api/routes/wormscan/operations/controller_test.go
+++ b/api/routes/wormscan/operations/controller_test.go
@@ -1,0 +1,111 @@
+package operations_test
+
+import (
+	"context"
+	"github.com/gofiber/fiber/v2"
+	"github.com/test-go/testify/mock"
+	ops "github.com/wormhole-foundation/wormhole-explorer/api/handlers/operations"
+	"github.com/wormhole-foundation/wormhole-explorer/api/middleware"
+	"github.com/wormhole-foundation/wormhole-explorer/api/routes/wormscan/operations"
+	"github.com/wormhole-foundation/wormhole-explorer/common/types"
+	"github.com/wormhole-foundation/wormhole/sdk/vaa"
+	"go.uber.org/zap"
+	"io"
+	"net/http"
+	"slices"
+	"testing"
+)
+
+func Test_FindAll(t *testing.T) {
+
+	testCases := []struct {
+		name               string
+		requestURL         string
+		expectedStatusCode int
+		expectedResponse   string
+		setupServiceMock   func(*mockOpsService)
+	}{
+		{
+			name:               "Test_FindAll_SinglePayloadType",
+			requestURL:         "/api/v1/operations?payloadType=1",
+			expectedStatusCode: http.StatusOK,
+			expectedResponse:   `{"operations":[]}`,
+			setupServiceMock: func(mockService *mockOpsService) {
+				payloadTypeMatcher := mock.MatchedBy(func(filter ops.OperationFilter) bool {
+					return slices.Equal(filter.PayloadType, []int{1})
+				})
+				mockService.On("FindAll", mock.Anything, payloadTypeMatcher).Return([]*ops.OperationDto{}, nil)
+			},
+		},
+		{
+			name:               "Test_FindAll_MultiplePayloadType",
+			requestURL:         "/api/v1/operations?payloadType=1,2,3",
+			expectedStatusCode: http.StatusOK,
+			expectedResponse:   `{"operations":[]}`,
+			setupServiceMock: func(mockService *mockOpsService) {
+				payloadTypeMatcher := mock.MatchedBy(func(filter ops.OperationFilter) bool {
+					return slices.Equal(filter.PayloadType, []int{1, 2, 3})
+				})
+				mockService.On("FindAll", mock.Anything, payloadTypeMatcher).Return([]*ops.OperationDto{}, nil)
+			},
+		},
+		{
+			name:               "Test_FindAll_InvalidPayloadType",
+			requestURL:         "/api/v1/operations?payloadType=1,thisShouldBeANumber,3",
+			expectedStatusCode: http.StatusBadRequest,
+			expectedResponse:   `{"code":3,"message":"invalid payloadType","details":[{"request_id":"\u003cnil\u003e"}]}`,
+			setupServiceMock:   func(mockService *mockOpsService) {},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+
+			req, err := http.NewRequest(http.MethodGet, testCase.requestURL, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			mockService := &mockOpsService{}
+			testCase.setupServiceMock(mockService)
+
+			app := fiber.New(fiber.Config{
+				ErrorHandler:          middleware.ErrorHandler,
+				DisableStartupMessage: true,
+				Immutable:             true,
+			})
+			app.Get("/api/v1/operations", operations.NewController(mockService, zap.NewNop()).FindAll)
+
+			resp, _ := app.Test(req, 50000)
+			defer resp.Body.Close()
+
+			if resp.StatusCode != testCase.expectedStatusCode {
+				t.Fatalf("expected status code %d, got %d", testCase.expectedStatusCode, resp.StatusCode)
+			}
+
+			respBytes, err := io.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if string(respBytes) != testCase.expectedResponse {
+				t.Fatalf("expected response %s, got %s", testCase.expectedResponse, string(respBytes))
+			}
+
+		})
+	}
+
+}
+
+type mockOpsService struct {
+	mock.Mock
+}
+
+func (m *mockOpsService) FindById(ctx context.Context, chainID vaa.ChainID, emitter *types.Address, seq string) (*ops.OperationDto, error) {
+	args := m.Called(ctx, chainID, emitter, seq)
+	return args.Get(0).(*ops.OperationDto), args.Error(1)
+}
+func (m *mockOpsService) FindAll(ctx context.Context, filter ops.OperationFilter) ([]*ops.OperationDto, error) {
+	args := m.Called(ctx, filter)
+	return args.Get(0).([]*ops.OperationDto), args.Error(1)
+}

--- a/api/routes/wormscan/operations/controller_test.go
+++ b/api/routes/wormscan/operations/controller_test.go
@@ -76,7 +76,7 @@ func Test_FindAll(t *testing.T) {
 			})
 			app.Get("/api/v1/operations", operations.NewController(mockService, zap.NewNop()).FindAll)
 
-			resp, _ := app.Test(req, 50000)
+			resp, _ := app.Test(req, 1000)
 			defer resp.Body.Close()
 
 			if resp.StatusCode != testCase.expectedStatusCode {


### PR DESCRIPTION
- Issue: #1589 
- Add support for multiple payloadTypes in `/operations` endpoint.