### PR TITLE
[Blockchain Watcher] (FIX) Create validations in getBlock

### DIFF
--- a/blockchain-watcher/config/mainnet.json
+++ b/blockchain-watcher/config/mainnet.json
@@ -81,7 +81,7 @@
     "acala": {
       "network": "mainnet",
       "chainId": 12,
-      "rpcs": ["https://eth-rpc-acala.aca-api.network", "https://rpc.evm.acala.network"]
+      "rpcs": ["https://eth-rpc-acala.aca-api.network"]
     },
     "klaytn": {
       "network": "mainnet",
@@ -101,7 +101,7 @@
     "moonbeam": {
       "network": "mainnet",
       "chainId": 16,
-      "rpcs": ["https://rpc.api.moonbeam.network", "https://1rpc.io/glmr"]
+      "rpcs": ["https://rpc.api.moonbeam.network"]
     },
     "injective": {
       "network": "mainnet",

--- a/blockchain-watcher/src/domain/actions/evm/PollEvm.ts
+++ b/blockchain-watcher/src/domain/actions/evm/PollEvm.ts
@@ -65,6 +65,7 @@ export class PollEvm extends RunPollingJob {
 
   protected async get(): Promise<EvmLog[] | EvmTransaction[]> {
     this.latestBlockHeight = await this.blockRepo.getBlockHeight(
+      this.blockHeightCursor,
       this.cfg.chain,
       this.cfg.getCommitment()
     );

--- a/blockchain-watcher/src/domain/repositories.ts
+++ b/blockchain-watcher/src/domain/repositories.ts
@@ -27,7 +27,11 @@ import {
 } from "./entities";
 
 export interface EvmBlockRepository {
-  getBlockHeight(chain: string, finality: string): Promise<bigint>;
+  getBlockHeight(
+    blockHeightCursor: bigint | undefined,
+    chain: string,
+    finality: string
+  ): Promise<bigint>;
   getBlocks(
     chain: string,
     blockNumbers: Set<bigint>,
@@ -39,6 +43,7 @@ export interface EvmBlockRepository {
     hashNumbers: Set<string>
   ): Promise<Record<string, ReceiptTransaction>>;
   getBlock(
+    blockHeightCursor: bigint | undefined,
     chain: string,
     blockNumberOrTag: EvmTag | bigint,
     isTransactionsPresent: boolean

--- a/blockchain-watcher/src/infrastructure/repositories/evm/ArbitrumEvmJsonRPCBlockRepository.ts
+++ b/blockchain-watcher/src/infrastructure/repositories/evm/ArbitrumEvmJsonRPCBlockRepository.ts
@@ -23,7 +23,11 @@ export class ArbitrumEvmJsonRPCBlockRepository extends EvmJsonRPCBlockRepository
     this.latestL2Finalized = 0;
   }
 
-  async getBlockHeight(chain: string, finality: EvmTag): Promise<bigint> {
+  async getBlockHeight(
+    blockHeightCursor: bigint | undefined,
+    chain: string,
+    finality: EvmTag
+  ): Promise<bigint> {
     const metadataFileName = `arbitrum-${finality}`;
     const chainCfg = this.getCurrentChain(chain);
     let response: { result: BlockByNumberResult };
@@ -61,7 +65,11 @@ export class ArbitrumEvmJsonRPCBlockRepository extends EvmJsonRPCBlockRepository
     this.saveAssociatedL1Block(auxPersistedBlocks, associatedL1ArbBlock, l2BlockArbNumber);
 
     // Get the latest finalized L1 block ethereum number
-    const latestL1BlockEthNumber: bigint = await super.getBlockHeight(this.getL1Chain(), FINALIZED);
+    const latestL1BlockEthNumber: bigint = await super.getBlockHeight(
+      blockHeightCursor,
+      this.getL1Chain(),
+      FINALIZED
+    );
 
     // Search in the persisted list looking for finalized L2 block number
     this.searchFinalizedBlock(auxPersistedBlocks, latestL1BlockEthNumber);

--- a/blockchain-watcher/src/infrastructure/repositories/evm/BscEvmJsonRPCBlockRepository.ts
+++ b/blockchain-watcher/src/infrastructure/repositories/evm/BscEvmJsonRPCBlockRepository.ts
@@ -7,8 +7,12 @@ export class BscEvmJsonRPCBlockRepository extends EvmJsonRPCBlockRepository {
     super(cfg, pools);
   }
 
-  async getBlockHeight(chain: string, finality: EvmTag): Promise<bigint> {
-    const blockNumber: bigint = await super.getBlockHeight(chain, finality);
+  async getBlockHeight(
+    blockHeightCursor: bigint | undefined,
+    chain: string,
+    finality: EvmTag
+  ): Promise<bigint> {
+    const blockNumber: bigint = await super.getBlockHeight(blockHeightCursor, chain, finality);
     const lastBlock = Math.max(Number(blockNumber) - 15, 0);
     return BigInt(lastBlock);
   }

--- a/blockchain-watcher/src/infrastructure/repositories/evm/MoonbeamEvmJsonRPCBlockRepository.ts
+++ b/blockchain-watcher/src/infrastructure/repositories/evm/MoonbeamEvmJsonRPCBlockRepository.ts
@@ -15,20 +15,24 @@ export class MoonbeamEvmJsonRPCBlockRepository extends EvmJsonRPCBlockRepository
     super(cfg, pools);
   }
 
-  async getBlockHeight(chain: string, finality: EvmTag): Promise<bigint> {
+  async getBlockHeight(
+    blockHeightCursor: bigint | undefined,
+    chain: string,
+    finality: EvmTag
+  ): Promise<bigint> {
     let isBlockFinalized = false;
     let sleepTime = 100;
     let attempts = 0;
 
     const chainCfg = this.getCurrentChain(chain);
-    const blockNumber: bigint = await super.getBlockHeight(chain, finality);
+    const blockNumber: bigint = await super.getBlockHeight(blockHeightCursor, chain, finality);
 
     while (!isBlockFinalized && attempts <= MAX_ATTEMPTS) {
       const provider = getChainProvider(chain, this.pool);
       try {
         await this.sleep(sleepTime);
 
-        const { hash } = await super.getBlock(chain, blockNumber);
+        const { hash } = await super.getBlock(blockHeightCursor, chain, blockNumber);
         const { result } = await provider.post<BlockIsFinalizedResult>(
           {
             jsonrpc: "2.0",

--- a/blockchain-watcher/src/infrastructure/repositories/evm/PolygonEvmJsonRPCBlockRepository.ts
+++ b/blockchain-watcher/src/infrastructure/repositories/evm/PolygonEvmJsonRPCBlockRepository.ts
@@ -12,7 +12,11 @@ export class PolygonJsonRPCBlockRepository extends EvmJsonRPCBlockRepository {
     super(cfg, pools);
   }
 
-  async getBlockHeight(chain: string, finality: EvmTag): Promise<bigint> {
+  async getBlockHeight(
+    blockHeightCursor: bigint | undefined,
+    chain: string,
+    finality: EvmTag
+  ): Promise<bigint> {
     if (finality == FINALIZED) {
       try {
         const rootChain = new ethers.utils.Interface([
@@ -37,7 +41,7 @@ export class PolygonJsonRPCBlockRepository extends EvmJsonRPCBlockRepository {
       }
     }
 
-    return await super.getBlockHeight(chain, finality);
+    return await super.getBlockHeight(blockHeightCursor, chain, finality);
   }
 }
 

--- a/blockchain-watcher/src/infrastructure/repositories/evm/RateLimitedEvmJsonRPCBlockRepository.ts
+++ b/blockchain-watcher/src/infrastructure/repositories/evm/RateLimitedEvmJsonRPCBlockRepository.ts
@@ -23,8 +23,14 @@ export class RateLimitedEvmJsonRPCBlockRepository
     this.logger = winston.child({ module: "RateLimitedEvmJsonRPCBlockRepository" });
   }
 
-  getBlockHeight(chain: string, finality: string): Promise<bigint> {
-    return this.breaker.fn(() => this.delegate.getBlockHeight(chain, finality)).execute();
+  getBlockHeight(
+    blockHeightCursor: bigint | undefined,
+    chain: string,
+    finality: string
+  ): Promise<bigint> {
+    return this.breaker
+      .fn(() => this.delegate.getBlockHeight(blockHeightCursor, chain, finality))
+      .execute();
   }
 
   getBlocks(
@@ -49,12 +55,15 @@ export class RateLimitedEvmJsonRPCBlockRepository
   }
 
   getBlock(
+    blockHeightCursor: bigint | undefined,
     chain: string,
     blockNumberOrTag: bigint | EvmTag,
     isTransactionsPresent: boolean
   ): Promise<EvmBlock> {
     return this.breaker
-      .fn(() => this.delegate.getBlock(chain, blockNumberOrTag, isTransactionsPresent))
+      .fn(() =>
+        this.delegate.getBlock(blockHeightCursor, chain, blockNumberOrTag, isTransactionsPresent)
+      )
       .execute();
   }
 }

--- a/blockchain-watcher/test/infrastructure/repositories/ArbitrumEvmJsonRPCBlockRepository.test.ts
+++ b/blockchain-watcher/test/infrastructure/repositories/ArbitrumEvmJsonRPCBlockRepository.test.ts
@@ -44,7 +44,7 @@ describe("ArbitrumEvmJsonRPCBlockRepository", () => {
     givenBlockHeightIs(originalBlock, "finalized");
 
     // When
-    const result = await repo.getBlockHeight(arbitrum, "latest");
+    const result = await repo.getBlockHeight(252076229n, arbitrum, "latest");
 
     // Then
     expect(result).toBe(expectedBlock);
@@ -68,7 +68,7 @@ describe("ArbitrumEvmJsonRPCBlockRepository", () => {
 
     try {
       // When
-      await repo.getBlockHeight(arbitrum, "latest");
+      await repo.getBlockHeight(252076229n, arbitrum, "latest");
     } catch (e: Error | any) {
       // Then
       expect(e).toBeInstanceOf(Error);

--- a/blockchain-watcher/test/infrastructure/repositories/BscEvmJsonRPCBlockRepository.test.ts
+++ b/blockchain-watcher/test/infrastructure/repositories/BscEvmJsonRPCBlockRepository.test.ts
@@ -32,7 +32,7 @@ describe("BscEvmJsonRPCBlockRepository", () => {
     givenBlockHeightIs(originalBlock, "latest");
 
     // When
-    const result = await repo.getBlockHeight(bsc, "latest");
+    const result = await repo.getBlockHeight(1980809n, bsc, "latest");
 
     // Then
     expect(result).toBe(expectedBlock);

--- a/blockchain-watcher/test/infrastructure/repositories/EvmJsonRPCBlockRepository.integration.test.ts
+++ b/blockchain-watcher/test/infrastructure/repositories/EvmJsonRPCBlockRepository.integration.test.ts
@@ -38,7 +38,7 @@ describe("EvmJsonRPCBlockRepository", () => {
     givenARepo();
     givenBlockHeightIs(expectedHeight, "latest");
 
-    const result = await repo.getBlockHeight(eth, "latest");
+    const result = await repo.getBlockHeight(1980809n, eth, "latest");
 
     expect(result).toBe(expectedHeight);
   });

--- a/blockchain-watcher/test/infrastructure/repositories/MoonbeamEvmJsonRPCBlockRepository.test.ts
+++ b/blockchain-watcher/test/infrastructure/repositories/MoonbeamEvmJsonRPCBlockRepository.test.ts
@@ -34,7 +34,7 @@ describe("MoonbeamEvmJsonRPCBlockRepository", () => {
     givenFinalizedBlock(block);
 
     // When
-    const result = await repo.getBlockHeight(moonbeam, "latest");
+    const result = await repo.getBlockHeight(19808090n, moonbeam, "latest");
 
     // Then
     expect(result).toBe(block);

--- a/deploy/blockchain-watcher/workers/source-events-1.yaml
+++ b/deploy/blockchain-watcher/workers/source-events-1.yaml
@@ -778,6 +778,10 @@ spec:
             - name: ETHEREUM_HOLESKY_RPCS
               value: '{{ .ETHEREUM_HOLESKY_RPCS }}'
             {{ end }}
+            {{ if .ACALA_RPCS }}
+            - name: ACALA_RPCS
+              value: '{{ .ACALA_RPCS }}'
+            {{ end }}
           resources:
             limits:
               cpu: {{ .RESOURCES_LIMITS_CPU }}

--- a/deploy/blockchain-watcher/workers/target-events-3.yaml
+++ b/deploy/blockchain-watcher/workers/target-events-3.yaml
@@ -716,6 +716,10 @@ spec:
             - name: TERRA2_RPCS
               value: '{{ .TERRA2_RPCS }}'
             {{ end }}
+            {{ if .ACALA_RPCS }}
+            - name: ACALA_RPCS
+              value: '{{ .ACALA_RPCS }}'
+            {{ end }}
           resources:
             limits:
               cpu: {{ .RESOURCES_LIMITS_CPU }}


### PR DESCRIPTION
## Problem:
When we receive an `ahead block heigh` we can't control the `to` in the query of the block process

`- Example normal flow`
actual heigh process: from 100 to 200 
block batch by 100
new block heigh by blockchain: 230
process block: from 200 to 230 (in this case we control the to and we can't stay ahead of the latest block in the blockchain)

`- Example ahead flow`
actual heigh process: from 100 to 200 
block batch by 100
new block heigh by blockchain: 3300 (The problem stays here, the RPC return and ahead block)
process block: from 200 to 300 (in this case we cannot control the to block, and we will process blocks wrong)

## Screenshot
ACALA blockchain
<img width="1402" alt="image" src="https://github.com/user-attachments/assets/1f4e3c47-e578-40d7-917f-7e021ba69538">

RPC response
<img width="540" alt="image" src="https://github.com/user-attachments/assets/50c0af4e-0ec2-452c-aaf3-103a986088bb">



