### PR TITLE
Added feature - CoinGecko show current price

### DIFF
--- a/common/coingecko/types.go
+++ b/common/coingecko/types.go
@@ -151,6 +151,9 @@ type CoinMarketDataResponse struct {
 		MarketCap struct {
 			Usd *decimal.Decimal `json:"usd"`
 		} `json:"market_cap"`
+		CurrentPrice struct {
+			Usd *decimal.Decimal `json:"usd`
+		} `json:"current_price"`
 		CirculatingSupply *decimal.Decimal `json:"circulating_supply"`
 	} `json:"market_data"`
 }


### PR DESCRIPTION
GetMarketData will now show current price along with market cap and circulating supply.