### PR TITLE
[Blockchain Watcher](FIX) Fix algorand mapper

### DIFF
--- a/blockchain-watcher/src/infrastructure/mappers/algorand/algorandRedeemedTransactionFoundMapper.ts
+++ b/blockchain-watcher/src/infrastructure/mappers/algorand/algorandRedeemedTransactionFoundMapper.ts
@@ -74,7 +74,7 @@ const mappedVaaInformation = (payload: string): VaaInformation | undefined => {
       emitterAddress: vaa.emitterAddress.toString("hex").toUpperCase(),
       sequence: Number(vaa.sequence),
     };
-  } catch (error) {
+  } catch (e) {
     // If we cant parse the VAA we ignore
     return undefined;
   }

--- a/blockchain-watcher/src/infrastructure/mappers/algorand/algorandRedeemedTransactionFoundMapper.ts
+++ b/blockchain-watcher/src/infrastructure/mappers/algorand/algorandRedeemedTransactionFoundMapper.ts
@@ -64,15 +64,20 @@ export const algorandRedeemedTransactionFoundMapper = (
 };
 
 const mappedVaaInformation = (payload: string): VaaInformation | undefined => {
-  const payloadToHex = Buffer.from(payload, "base64").toString("hex");
-  const buffer = Buffer.from(payloadToHex, "hex");
-  const vaa = parseVaa(buffer);
+  try {
+    const payloadToHex = Buffer.from(payload, "base64").toString("hex");
+    const buffer = Buffer.from(payloadToHex, "hex");
+    const vaa = parseVaa(buffer);
 
-  return {
-    emitterChain: vaa.emitterChain,
-    emitterAddress: vaa.emitterAddress.toString("hex").toUpperCase(),
-    sequence: Number(vaa.sequence),
-  };
+    return {
+      emitterChain: vaa.emitterChain,
+      emitterAddress: vaa.emitterAddress.toString("hex").toUpperCase(),
+      sequence: Number(vaa.sequence),
+    };
+  } catch (error) {
+    // If we cant parse the VAA we ignore
+    return undefined;
+  }
 };
 
 type VaaInformation = {

--- a/blockchain-watcher/src/infrastructure/repositories/target/SnsEventRepository.ts
+++ b/blockchain-watcher/src/infrastructure/repositories/target/SnsEventRepository.ts
@@ -127,8 +127,12 @@ export class SnsEvent {
   }
 
   static fromLogFoundEvent<T>(logFoundEvent: LogFoundEvent<T>): SnsEvent {
+    const prefix = `chain-event-${uuidv4()}-${logFoundEvent.txHash}`;
+    // SNS message attributes have a limit of 127 characters
+    const trackId = prefix.length > 127 ? prefix.substring(0, 127) : prefix;
+
     return new SnsEvent(
-      `chain-event-${uuidv4()}-${logFoundEvent.txHash}`,
+      trackId,
       "blockchain-watcher",
       logFoundEvent.name,
       new Date().toISOString(),


### PR DESCRIPTION
## Description
Issue in production yesterday about algorand process.

- If we cant process the vaa payload we skip
- Add logic to create the trackId in sns properties (de duplicated value)

![image](https://github.com/user-attachments/assets/89d2d3b7-c7e4-4374-9bd4-5ad39082ed2a)

- Re-process _**vaa**_ yesterday
<img width="955" alt="image" src="https://github.com/user-attachments/assets/19337ff0-5365-415a-b614-cf1a0f8c8b6f">

